### PR TITLE
Align Ukrainian index with English homepage layout

### DIFF
--- a/index-ukraine.rst
+++ b/index-ukraine.rst
@@ -1,13 +1,15 @@
-================================================
-PySDR: Посібник з SDR та DSP за допомогою Python
-================================================
+.. raw:: html
+   :file: _templates/homepage.html
 
-автор :ref:`Доктор Марк Ліхтман<author-chapter>`
+.. raw:: html
+
+   <details>
+   <summary><h4 style="display: inline;">Розгорнути повний зміст</h4></summary>
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
    :numbered: 1
-   
+
    content-ukraine/intro
    content-ukraine/frequency_domain
    content-ukraine/sampling
@@ -26,3 +28,7 @@ PySDR: Посібник з SDR та DSP за допомогою Python
    content-ukraine/doa
    content-ukraine/phaser
    content-ukraine/about_author
+
+.. raw:: html
+
+   </details>


### PR DESCRIPTION
## Summary
- align the Ukrainian index page with the updated English homepage structure
- translate the "expand" caption and match the toctree configuration to the source document

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3d669b6c48328950d51a48b536b6a