### PR TITLE
Translate bladeRF guide to Ukrainian

### DIFF
--- a/content-ukraine/bladerf.rst
+++ b/content-ukraine/bladerf.rst
@@ -1,49 +1,49 @@
 .. _bladerf-chapter:
 
 ##################
-BladeRF in Python
+BladeRF у Python
 ##################
 
-The bladeRF 2.0 (a.k.a. bladeRF 2.0 micro) from the company `Nuand <https://www.nuand.com>`_ is a USB 3.0-based SDR with two receive channels, two transmit channels, a tunable range of 47 MHz to 6 GHz, and the ability to sample up to 61 MHz or as high as 122 MHz when hacked.  It uses the AD9361 RF integrated circuit (RFIC) just like the USRP B210 and PlutoSDR, so RF performance will be similar.  The bladeRF 2.0 was released in 2021, maintains a small form factor at 2.5" x 4.5", and comes in two different FPGA sizes (xA4 and xA9).  While this chapter focuses on the bladeRF 2.0, a lot of the code will also apply to the original bladeRF which `came out in 2013 <https://www.kickstarter.com/projects/1085541682/bladerf-usb-30-software-defined-radio>`_.
+bladeRF 2.0 (a.k.a. bladeRF 2.0 micro) від компанії `Nuand <https://www.nuand.com>`_ — це SDR на базі USB 3.0 з двома каналами прийому, двома каналами передавання, робочим діапазоном налаштування від 47 МГц до 6 ГГц та можливістю дискретизації до 61 МГц або навіть до 122 МГц після модифікації. Він використовує радіочастотну інтегральну схему (RFIC) AD9361 так само, як USRP B210 та PlutoSDR, тому його радіочастотні характеристики будуть подібними. bladeRF 2.0 було випущено у 2021 році, він зберіг компактний форм-фактор 2.5" x 4.5" і постачається з двома варіантами FPGA (xA4 та xA9). Хоча цей розділ зосереджується на bladeRF 2.0, більшість наведеного коду також застосовна до оригінального bladeRF, який `з'явився у 2013 році <https://www.kickstarter.com/projects/1085541682/bladerf-usb-30-software-defined-radio>`_.
 
 .. image:: ../_images/bladeRF_micro.png
    :scale: 35 %
-   :align: center 
+   :align: center
    :alt: bladeRF 2.0 glamour shot
 
 ********************************
-bladeRF Architecture
+Архітектура bladeRF
 ********************************
 
-At a high level, the bladeRF 2.0 is based on the AD9361 RFIC, combined with a Cyclone V FPGA (either the 49 kLE :code:`5CEA4` or 301 kLE :code:`5CEA9`), and a Cypress FX3 USB 3.0 controller that has a 200 MHz ARM9 core inside, loaded with custom firmware.  The block diagram of the bladeRF 2.0 is shown below:
+На високому рівні bladeRF 2.0 побудований на базі RFIC AD9361 у поєднанні з FPGA Cyclone V (або 49 kLE :code:`5CEA4`, або 301 kLE :code:`5CEA9`) та контролером Cypress FX3 USB 3.0 із ядром ARM9 на частоті 200 МГц, що працює під керуванням спеціальної прошивки. Нижче наведена блок-схема bladeRF 2.0:
 
 .. image:: ../_images/bladeRF-2.0-micro-Block-Diagram-4.png
    :scale: 80 %
-   :align: center 
+   :align: center
    :alt: bladeRF 2.0 block diagram
 
-The FPGA controls the RFIC, performs digital filtering, and frames packets for transfer over USB (among other things).  The `source code <https://github.com/Nuand/bladeRF/tree/master/hdl>`_ for the FPGA image is written in VHDL and requires the free Quartus Prime Lite design software to compile custom images.  Precompiled images are available `here <https://www.nuand.com/fpga_images/>`_.
+FPGA керує RFIC, виконує цифрову фільтрацію та формує пакети для передавання через USB (серед іншого). `Вихідний код <https://github.com/Nuand/bladeRF/tree/master/hdl>`_ для образу FPGA написаний VHDL і вимагає безкоштовного програмного забезпечення Quartus Prime Lite для компіляції власних образів. Готові образи доступні `тут <https://www.nuand.com/fpga_images/>`_.
 
-The `source code <https://github.com/Nuand/bladeRF/tree/master/fx3_firmware>`_ for the Cypress FX3 firmware is open-source and includes code to:
+`Вихідний код <https://github.com/Nuand/bladeRF/tree/master/fx3_firmware>`_ для прошивки Cypress FX3 з відкритим кодом і містить реалізацію:
 
-1. Load the FPGA image
-2. Transfer IQ samples between the FPGA and host over USB 3.0
-3. Control GPIO of the FPGA over UART
+1. Завантаження образу FPGA
+2. Передавання IQ-вибірок між FPGA та хостом через USB 3.0
+3. Керування GPIO FPGA через UART
 
-From a signal flow perspective, there are two receive channels and two transmit channels, and each channel has a low and high frequency input/output to the RFIC, depending on which band is being used.  It is for this reason that a single pole double throw (SPDT) electronic RF switch is needed between the RFIC and SMA connectors.  The bias tee is an onboard circuit that provides ~4.5V DC on the SMA connector, and is used to conveniently power an external amplifier or other RF components.  This extra DC offset is on the RF side of the SDR so it does not interfere with the basic receiving/transmitting operation.
+З точки зору потоку сигналу є два канали прийому та два канали передавання, і кожен канал має низькочастотний та високочастотний вхід/вихід до RFIC залежно від обраного діапазону. Саме тому між RFIC та SMA-роз'ємами потрібен електронний ВКП перемикач (single pole double throw, SPDT). Bias tee — це вбудована схема, що подає ~4,5 В постійного струму на SMA-роз'єм і дозволяє зручно живити зовнішній підсилювач чи інші ВЧ-компоненти. Ця додаткова напруга постійного струму знаходиться на радіочастотній стороні SDR, тому вона не заважає базовій роботі прийому/передавання.
 
-JTAG is a type of debugging interface, allowing for testing and verifying designs during the development process.
+JTAG — це інтерфейс налагодження, який дозволяє тестувати та перевіряти проєкти під час розробки.
 
-At the end of this chapter, we discuss the VCTCXO oscillator, PLL, and expansion port.
+Наприкінці цього розділу ми обговоримо генератор VCTCXO, PLL та розширювальний порт.
 
 ********************************
-Software and Hardware Setup
+Налаштування програмного та апаратного забезпечення
 ********************************
 
-Ubuntu (or Ubuntu within WSL)
+Ubuntu (або Ubuntu у WSL)
 #############################
 
-On Ubuntu and other Debian-based systems, you can install the bladeRF software with the following commands:
+В Ubuntu та інших системах на базі Debian можна встановити програмне забезпечення bladeRF наступними командами:
 
 .. code-block:: bash
 
@@ -60,56 +60,56 @@ On Ubuntu and other Debian-based systems, you can install the bladeRF software w
  cd ../libraries/libbladeRF_bindings/python
  sudo python3 setup.py install
 
-This will install the libbladerf library, Python bindings, bladeRF command line tools, the firmware downloader, and the FPGA bitstream downloader.  To check which version of the library you installed, use :code:`bladerf-tool version` (this guide was written using libbladeRF version v2.5.0).
+Це встановить бібліотеку libbladerf, Python-біндінги, інструменти командного рядка bladeRF, засіб завантаження прошивки та засіб завантаження бітстрімів FPGA. Щоб перевірити встановлену версію бібліотеки, скористайтеся :code:`bladerf-tool version` (цей посібник написано для libbladeRF версії v2.5.0).
 
-If you are using Ubuntu through WSL, on the Windows side you will need to forward the bladeRF USB device to WSL, first by installing the latest `usbipd utility msi <https://github.com/dorssel/usbipd-win/releases>`_ (this guide assumes you have usbipd-win 4.0.0 or higher), then opening PowerShell in administrator mode and running:
+Якщо ви використовуєте Ubuntu через WSL, на стороні Windows необхідно переслати USB-пристрій bladeRF у WSL. Спочатку встановіть останній `msi-дистрибутив утиліти usbipd <https://github.com/dorssel/usbipd-win/releases>`_ (цей посібник припускає, що у вас usbipd-win 4.0.0 або новіший), потім відкрийте PowerShell від імені адміністратора та виконайте:
 
 .. code-block:: bash
 
     usbipd list
-    # (find the BUSID labeled bladeRF 2.0 and substitute it in the command below)
+    # (знайдіть BUSID з позначкою bladeRF 2.0 і підставте його в команду нижче)
     usbipd bind --busid 1-23
     usbipd attach --wsl --busid 1-23
 
-On the WSL side, you should be able to run :code:`lsusb` and see a new item called :code:`Nuand LLC bladeRF 2.0 micro`.  Note that you can add the :code:`--auto-attach` flag to the :code:`usbipd attach` command if you want it to auto reconnect.
+У WSL ви маєте змогу виконати :code:`lsusb` і побачити новий елемент :code:`Nuand LLC bladeRF 2.0 micro`. Зауважте, що до команди :code:`usbipd attach` можна додати прапорець :code:`--auto-attach`, якщо потрібне автоматичне повторне підключення.
 
-(Might not be needed) For both native Linux and WSL, we must install the udev rules so that we don't get permissions errors:
+(Може не знадобитися) Для нативного Linux і WSL потрібно встановити правила udev, щоб уникнути помилок доступу:
 
 .. code-block::
 
  sudo nano /etc/udev/rules.d/88-nuand.rules
 
-and paste in the following line:
+та вставити такий рядок:
 
 .. code-block::
 
  ATTRS{idVendor}=="2cf0", ATTRS{idProduct}=="5250", MODE="0666"
 
-To save and exit from nano, use: control-o, then Enter, then control-x.  To refresh udev, run:
+Щоб зберегти та вийти з nano, натисніть: control-o, потім Enter, потім control-x. Для оновлення udev виконайте:
 
 .. code-block:: bash
 
     sudo udevadm control --reload-rules && sudo udevadm trigger
 
-If you are using WSL and it says :code:`Failed to send reload request: No such file or directory`, that means the udev service isn't running, and you will need to :code:`sudo nano /etc/wsl.conf` and add the lines:
+Якщо ви використовуєте WSL і бачите повідомлення :code:`Failed to send reload request: No such file or directory`, це означає, що служба udev не запущена, і вам потрібно виконати :code:`sudo nano /etc/wsl.conf` та додати рядки:
 
 .. code-block:: bash
 
  [boot]
  command="service udev start"
 
-then restart WSL using the following command in PowerShell with admin: :code:`wsl.exe --shutdown`.
+Потім перезавантажте WSL такою командою в PowerShell з правами адміністратора: :code:`wsl.exe --shutdown`.
 
-Unplug and replug your bladeRF (WSL users will have to reattach), and test permissions with:
+Від'єднайте та знову під'єднайте bladeRF (користувачам WSL доведеться повторно приєднати пристрій) і перевірте права доступу командами:
 
 .. code-block:: bash
 
  bladerf-tool probe
  bladerf-tool info
 
-and you'll know it worked if you see your bladeRF 2.0 listed, and you **don't** see :code:`Found a bladeRF via VID/PID, but could not open it due to insufficient permissions`.  If it worked, note reported FPGA Version and Firmware Version.
+Ви зрозумієте, що все спрацювало, якщо ваш bladeRF 2.0 буде в списку і ви **не** побачите повідомлення :code:`Found a bladeRF via VID/PID, but could not open it due to insufficient permissions`. Якщо все вдалося, зверніть увагу на версії FPGA та прошивки, що виводяться.
 
-(Optionally) Install the latest firmware and FPGA images (v2.4.0 and v0.15.0 respectively when this guide was written) using:
+(Опційно) Встановіть найновішу прошивку та образи FPGA (відповідно v2.4.0 та v0.15.0 на момент написання посібника) командами:
 
 .. code-block:: bash
 
@@ -117,25 +117,25 @@ and you'll know it worked if you see your bladeRF 2.0 listed, and you **don't** 
  wget https://www.nuand.com/fx3/bladeRF_fw_latest.img
  bladerf-tool flash_fw bladeRF_fw_latest.img
 
- # for xA4 use:
+ # для xA4 використовуйте:
  wget https://www.nuand.com/fpga/hostedxA4-latest.rbf
  bladerf-tool flash_fpga hostedxA4-latest.rbf
 
- # for xA9 use:
+ # для xA9 використовуйте:
  wget https://www.nuand.com/fpga/hostedxA9-latest.rbf
  bladerf-tool flash_fpga hostedxA9-latest.rbf
 
-Unplug and plug in your bladeRF to cycle power.
+Від'єднайте та знову під'єднайте bladeRF, щоб перезапустити живлення.
 
-Now we will test its functionality by receiving 1M samples in the FM radio band, at 10 MHz sample rate, to a file /tmp/samples.sc16:
+Тепер перевіримо працездатність, прийнявши 1 млн вибірок у FM-діапазоні радіо з частотою дискретизації 10 МГц у файл /tmp/samples.sc16:
 
 .. code-block:: bash
 
  bladerf-tool rx --num-samples 1000000 /tmp/samples.sc16 100e6 10e6
 
-a couple :code:`Hit stall for buffer` is expected, but you'll know if it worked if you see a 4MB /tmp/samples.sc16 file.
+Кілька повідомлень :code:`Hit stall for buffer` наприкінці — це нормально, а успішним результатом буде поява файлу /tmp/samples.sc16 обсягом 4 МБ.
 
-Lastly, we will test the Python API with:
+Нарешті, перевіримо Python API:
 
 .. code-block:: bash
 
@@ -144,18 +144,18 @@ Lastly, we will test the Python API with:
  bladerf.BladeRF()
  exit()
 
-You'll know it worked if you see something like :code:`<BladeRF(<DevInfo(...)>)>` and no warnings/errors.
+Ви зрозумієте, що все працює, якщо побачите щось на кшталт :code:`<BladeRF(<DevInfo(...)>)>` і не з'являться попередження чи помилки.
 
-Windows and macOS
+Windows і macOS
 ###################
 
-For Windows users (who do not prefer to use WSL), see https://github.com/Nuand/bladeRF/wiki/Getting-Started%3A-Windows, and for macOS users, see https://github.com/Nuand/bladeRF/wiki/Getting-started:-Mac-OSX.
+Користувачам Windows (які не бажають використовувати WSL) див. https://github.com/Nuand/bladeRF/wiki/Getting-Started%3A-Windows, а користувачам macOS — https://github.com/Nuand/bladeRF/wiki/Getting-started:-Mac-OSX.
 
 ********************************
-bladeRF Python API Basics
+Основи Python API bladeRF
 ********************************
 
-To start with, let's poll the bladeRF for some useful information, using the following script.  **Do not name your script bladerf.py** or it will conflict with the bladeRF Python module itself!
+Почнімо з опитування bladeRF щодо корисної інформації за допомогою такого скрипта. **Не називайте свій скрипт bladerf.py**, інакше він конфліктуватиме з самим модулем Python bladeRF!
 
 .. code-block:: python
 
@@ -164,23 +164,23 @@ To start with, let's poll the bladeRF for some useful information, using the fol
  import matplotlib.pyplot as plt
 
  sdr = _bladerf.BladeRF()
- 
+
  print("Device info:", _bladerf.get_device_list()[0])
  print("libbladeRF version:", _bladerf.version()) # v2.5.0
  print("Firmware version:", sdr.get_fw_version()) # v2.4.0
  print("FPGA version:", sdr.get_fpga_version())   # v0.15.0
- 
- rx_ch = sdr.Channel(_bladerf.CHANNEL_RX(0)) # give it a 0 or 1
+
+ rx_ch = sdr.Channel(_bladerf.CHANNEL_RX(0)) # задайте 0 або 1
  print("sample_rate_range:", rx_ch.sample_rate_range)
  print("bandwidth_range:", rx_ch.bandwidth_range)
  print("frequency_range:", rx_ch.frequency_range)
  print("gain_modes:", rx_ch.gain_modes)
- print("manual gain range:", sdr.get_gain_range(_bladerf.CHANNEL_RX(0))) # ch 0 or 1
+ print("manual gain range:", sdr.get_gain_range(_bladerf.CHANNEL_RX(0))) # канал 0 або 1
 
-For the bladeRF 2.0 xA9, the output should look something like:
+Для bladeRF 2.0 xA9 результат виглядатиме приблизно так:
 
 .. code-block:: python
- 
+
     Device info: Device Information
         backend  libusb
         serial   f80a27b1010448dfb7a003ef7fa98a59
@@ -216,17 +216,17 @@ For the bladeRF 2.0 xA9, the output should look something like:
         step  1
         scale 1.0
 
-The bandwidth parameter sets the filter used by the SDR when performing the receive operation, so we typically set it to be equal or slightly less than the sample_rate/2.  The gain modes are important to understand, the SDR uses either a manual gain mode where you provide the gain in dB, or automatic gain control (AGC) which has three different settings (fast, slow, hybrid).  For applications such as spectrum monitoring, manual gain is advised (so you can see when signals come and go), but for applications such as receiving a specific signal you expect to exist, AGC will be more useful because it will automatically adjust the gain to allow the signal to fill the analog-to-digital converter (ADC).
+Параметр bandwidth встановлює фільтр, який використовує SDR під час прийому, тому зазвичай його задають рівним або трохи меншим за sample_rate/2. Режими підсилення важливо розуміти: SDR може працювати або в режимі ручного підсилення, коли ви задаєте значення в дБ, або в режимі автоматичного керування підсиленням (AGC), що має три налаштування (швидке, повільне, гібридне). Для задач на кшталт моніторингу спектра рекомендується ручний режим (щоб бачити, коли сигнали з'являються і зникають), а для задач на кшталт прийому конкретного сигналу, який ви очікуєте, AGC буде кориснішим, бо автоматично підбиратиме підсилення так, щоб сигнал максимально заповнював аналогово-цифровий перетворювач (ADC).
 
-To set the main parameters of the SDR, we can add the following code:
+Щоб задати основні параметри SDR, додайте такий код:
 
 .. code-block:: python
 
  sample_rate = 10e6
  center_freq = 100e6
- gain = 50 # -15 to 60 dB
+ gain = 50 # від -15 до 60 дБ
  num_samples = int(1e6)
- 
+
  rx_ch.frequency = center_freq
  rx_ch.sample_rate = sample_rate
  rx_ch.bandwidth = sample_rate/2
@@ -234,31 +234,31 @@ To set the main parameters of the SDR, we can add the following code:
  rx_ch.gain = gain
 
 ********************************
-Receiving Samples in Python
+Приймання вибірок у Python
 ********************************
 
-Next, we will work off the previous code block to receive 1M samples in the FM radio band, at 10 MHz sample rate, just like we did before.  Any antenna on the RX1 port should be able to receive FM, since it is so strong.  The code below shows how the bladeRF synchronous stream API works; it must be configured and a receive buffer must be created, before the receiving begins.  The :code:`while True:` loop will continue to receive samples until the number of samples requested is reached.  The received samples are stored in a separate numpy array, so that we can process them after the loop finishes.
+Далі, спираючись на попередній приклад, приймемо 1 млн вибірок у FM-діапазоні з частотою дискретизації 10 МГц, як ми робили раніше. Будь-яка антена на порту RX1 має приймати FM, бо сигнал дуже потужний. Код нижче демонструє роботу синхронного потокового API bladeRF: перед початком прийому його потрібно налаштувати і створити буфер. Цикл :code:`while True:` продовжить приймати вибірки, доки не буде досягнуто потрібної кількості. Отримані вибірки зберігаються в окремому масиві numpy, щоб ми могли обробити їх після завершення циклу.
 
 .. code-block:: python
 
- # Setup synchronous stream
- sdr.sync_config(layout = _bladerf.ChannelLayout.RX_X1, # or RX_X2
-                 fmt = _bladerf.Format.SC16_Q11, # int16s
+ # Налаштування синхронного потоку
+ sdr.sync_config(layout = _bladerf.ChannelLayout.RX_X1, # або RX_X2
+                 fmt = _bladerf.Format.SC16_Q11, # int16
                  num_buffers    = 16,
                  buffer_size    = 8192,
                  num_transfers  = 8,
                  stream_timeout = 3500)
- 
- # Create receive buffer
- bytes_per_sample = 4 # don't change this, it will always use int16s
+
+ # Створення приймального буфера
+ bytes_per_sample = 4 # не змінюйте, завжди використовуються int16
  buf = bytearray(1024 * bytes_per_sample)
- 
- # Enable module
+
+ # Увімкнення модуля
  print("Starting receive")
  rx_ch.enable = True
- 
- # Receive loop
- x = np.zeros(num_samples, dtype=np.complex64) # storage for IQ samples
+
+ # Цикл прийому
+ x = np.zeros(num_samples, dtype=np.complex64) # сховище для IQ-вибірок
  num_samples_read = 0
  while True:
      if num_samples > 0 and num_samples_read == num_samples:
@@ -267,27 +267,27 @@ Next, we will work off the previous code block to receive 1M samples in the FM r
          num = min(len(buf) // bytes_per_sample, num_samples - num_samples_read)
      else:
          num = len(buf) // bytes_per_sample
-     sdr.sync_rx(buf, num) # Read into buffer
+     sdr.sync_rx(buf, num) # зчитування у буфер
      samples = np.frombuffer(buf, dtype=np.int16)
-     samples = samples[0::2] + 1j * samples[1::2] # Convert to complex type
-     samples /= 2048.0 # Scale to -1 to 1 (its using 12 bit ADC)
-     x[num_samples_read:num_samples_read+num] = samples[0:num] # Store buf in samples array
+     samples = samples[0::2] + 1j * samples[1::2] # перетворення у комплексний тип
+     samples /= 2048.0 # масштабування до -1...1 (використовується 12-бітний ADC)
+     x[num_samples_read:num_samples_read+num] = samples[0:num] # збереження буфера у масиві вибірок
      num_samples_read += num
- 
+
  print("Stopping")
  rx_ch.enable = False
- print(x[0:10]) # look at first 10 IQ samples
- print(np.max(x)) # if this is close to 1, you are overloading the ADC, and should reduce the gain
+ print(x[0:10]) # подивіться на перші 10 IQ-вибірок
+ print(np.max(x)) # якщо значення близьке до 1, ADC перевантажено і слід зменшити підсилення
 
-A few :code:`Hit stall for buffer` is expected at the end.  The last number printed shows the maximum sample received; you will want to adjust your gain to try to get that value around 0.5 to 0.8.  If it is 0.999 that means your receiver is overloaded/saturated and the signal is going to be distorted (it will look smeared throughout the frequency domain).
+Кілька повідомлень :code:`Hit stall for buffer` наприкінці — це очікувано. Останнє виведене число показує максимальну отриману вибірку; вам варто налаштувати підсилення так, щоб це значення було в діапазоні 0.5–0.8. Якщо ж воно дорівнює 0.999, приймач перевантажений/насичений, і сигнал спотворюється (у частотній області він виглядатиме розмитим).
 
-In order to visualize the received signal, let's display the IQ samples using a spectrogram (see :ref:`spectrogram-section` for more details on how spectrograms work).  Add the following to the end of the previous code block:
+Щоб візуалізувати отриманий сигнал, побудуймо спектрограму (детальніше про спектрограми див. :ref:`spectrogram-section`). Додайте наприкінці попереднього блоку коду:
 
 .. code-block:: python
 
- # Create spectrogram
+ # Побудова спектрограми
  fft_size = 2048
- num_rows = len(x) // fft_size # // is an integer division which rounds down
+ num_rows = len(x) // fft_size # // — цілочисельне ділення з округленням донизу
  spectrogram = np.zeros((num_rows, fft_size))
  for i in range(num_rows):
      spectrogram[i,:] = 10*np.log10(np.abs(np.fft.fftshift(np.fft.fft(x[i*fft_size:(i+1)*fft_size])))**2)
@@ -298,114 +298,112 @@ In order to visualize the received signal, let's display the IQ samples using a 
  plt.show()
 
 .. image:: ../_images/bladerf-waterfall.svg
-   :align: center 
+   :align: center
    :target: ../_images/bladerf-waterfall.svg
    :alt: bladeRF spectrogram example
 
-Each vertical squiggly line is an FM radio signal.  No clue what the pulsing on the right side is from, lowering the gain didn't make it go away.
-
+Кожна вертикальна хвиляста лінія — це сигнал FM-радіо. Невідомо, звідки береться пульсація праворуч; зменшення підсилення її не прибрало.
 
 ********************************
-Transmitting Samples in Python
+Передавання вибірок у Python
 ********************************
 
-The process of transmitting samples with the bladeRF is very similar to receiving.  The main difference is that we must generate the samples to transmit, and then write them to the bladeRF using the :code:`sync_tx` method which can handle our entire batch of samples at once (up to ~4B samples).  The code below shows how to transmit a simple tone, and then repeat it 30 times.  The tone is generated using numpy, and then scaled to be between -2048 and 2048 to fit the 12 bit digital-to-analog converter (DAC).  The tone is then converted to bytes representing int16's and used as the transmit buffer.  The synchronous stream API is used to transmit the samples, and the :code:`while True:` loop will continue to transmit samples until the number of repeats requested is reached.  If you want to transmit samples from a file instead, simply use :code:`samples = np.fromfile('yourfile.iq', dtype=np.int16)` (or whatever datatype they are) to read the samples, and then convert them to bytes using :code:`samples.tobytes()`, although keep in mind the -2048 to 2048 range of the DAC.
+Процес передавання вибірок на bladeRF дуже схожий на прийом. Головна відмінність у тому, що потрібно згенерувати вибірки для передавання, а потім записати їх у bladeRF за допомогою методу :code:`sync_tx`, який може обробити весь пакет вибірок одразу (до ~4 млрд вибірок). Наведений нижче код демонструє, як передати простий тон і повторити його 30 разів. Тон генерується за допомогою numpy, потім масштабується до діапазону від -2048 до 2048, щоб відповідати 12-бітному цифро-аналоговому перетворювачу (DAC). Далі тон перетворюється на байти, що представляють int16, і використовується як буфер передавання. Синхронний потоковий API використовується для передавання вибірок, а цикл :code:`while True:` триватиме, доки не буде зроблено потрібну кількість повторів. Якщо бажаєте передавати вибірки з файлу, просто виконайте :code:`samples = np.fromfile('yourfile.iq', dtype=np.int16)` (або з відповідним типом даних), щоб прочитати вибірки, а потім перетворіть їх у байти за допомогою :code:`samples.tobytes()`, пам'ятаючи про діапазон DAC від -2048 до 2048.
 
 .. code-block:: python
 
  from bladerf import _bladerf
  import numpy as np
- 
+
  sdr = _bladerf.BladeRF()
- tx_ch = sdr.Channel(_bladerf.CHANNEL_TX(0)) # give it a 0 or 1
- 
+ tx_ch = sdr.Channel(_bladerf.CHANNEL_TX(0)) # задайте 0 або 1
+
  sample_rate = 10e6
  center_freq = 100e6
- gain = 0 # -15 to 60 dB. for transmitting, start low and slowly increase, and make sure antenna is connected
+ gain = 0 # від -15 до 60 дБ. починайте з малого, поступово збільшуйте й переконайтеся, що антена під'єднана
  num_samples = int(1e6)
- repeat = 30 # number of times to repeat our signal
+ repeat = 30 # кількість повторів сигналу
  print('duration of transmission:', num_samples/sample_rate*repeat, 'seconds')
- 
- # Generate IQ samples to transmit (in this case, a simple tone)
+
+ # Генерація IQ-вибірок для передавання (у цьому випадку простого тону)
  t = np.arange(num_samples) / sample_rate
  f_tone = 1e6
- samples = np.exp(1j * 2 * np.pi * f_tone * t) # will be -1 to +1
+ samples = np.exp(1j * 2 * np.pi * f_tone * t) # значення від -1 до +1
  samples = samples.astype(np.complex64)
- samples *= 2048.0 # Scale to -1 to 1 (its using 12 bit DAC)
+ samples *= 2048.0 # масштабування до -1...1 (використовується 12-бітний DAC)
  samples = samples.view(np.int16)
- buf = samples.tobytes() # convert our samples to bytes and use them as transmit buffer
- 
+ buf = samples.tobytes() # перетворення вибірок у байти та використання їх як буфера передавання
+
  tx_ch.frequency = center_freq
  tx_ch.sample_rate = sample_rate
  tx_ch.bandwidth = sample_rate/2
  tx_ch.gain = gain
-  
- # Setup synchronous stream
- sdr.sync_config(layout=_bladerf.ChannelLayout.TX_X1, # or TX_X2
-                 fmt=_bladerf.Format.SC16_Q11, # int16s
+
+ # Налаштування синхронного потоку
+ sdr.sync_config(layout=_bladerf.ChannelLayout.TX_X1, # або TX_X2
+                 fmt=_bladerf.Format.SC16_Q11, # int16
                  num_buffers=16,
                  buffer_size=8192,
                  num_transfers=8,
                  stream_timeout=3500)
- 
+
  print("Starting transmit!")
  repeats_remaining = repeat - 1
  tx_ch.enable = True
  while True:
-     sdr.sync_tx(buf, num_samples) # write to bladeRF
+     sdr.sync_tx(buf, num_samples) # запис у bladeRF
      print(repeats_remaining)
      if repeats_remaining > 0:
          repeats_remaining -= 1
      else:
          break
- 
+
  print("Stopping transmit")
  tx_ch.enable = False
 
-A few :code:`Hit stall for buffer`'s at the end is expected.
+Кілька повідомлень :code:`Hit stall for buffer` наприкінці — це нормально.
 
-In order to transmit and receive at the same time, you have to use threads, and you might as well just use Nuand's example `txrx.py <https://github.com/Nuand/bladeRF/blob/624994d65c02ad414a01b29c84154260912f4e4f/host/examples/python/txrx/txrx.py>`_ which does exactly that.
+Щоб одночасно передавати та приймати, необхідно використовувати потоки. У такому випадку краще взяти приклад Nuand `txrx.py <https://github.com/Nuand/bladeRF/blob/624994d65c02ad414a01b29c84154260912f4e4f/host/examples/python/txrx/txrx.py>`_, який робить саме це.
 
 ***********************************
-Oscillators, PLLs, and Calibration
+Генератори, PLL та калібрування
 ***********************************
 
-All direct-conversion SDRs (including all AD9361-based SDRs like the USRP B2X0, Analog Devices Pluto, and bladeRF) rely on a single oscillator to provide a stable clock for the RF transceiver.  Any offsets or jitter in the frequency produced by this oscillator will translate to frequency offset and frequency jitter in the received or transmitted signal.  This oscillator is onboard, but can optionally be "disciplined" using a separate square or sine wave fed into the bladeRF through a U.FL connector on the board.  
+Усі SDR із прямим перетворенням (у тому числі всі пристрої на AD9361, як-от USRP B2X0, Analog Devices Pluto та bladeRF) покладаються на один генератор, що забезпечує стабільну тактову частоту для радіоприймача. Будь-які зміщення чи джитер частоти цього генератора перетворюються на частотне зміщення та джитер у прийнятому або переданому сигналі. Цей генератор розташований на платі, але його можна «дисциплінувати», підключивши окремий квадратний або синусоїдальний сигнал до bladeRF через роз'єм U.FL на платі.
 
-Onboard the bladeRF is an `Abracon VCTCXO <https://abracon.com/Oscillators/ASTX12_ASVTX12.pdf>`_ (Voltage-controlled 
-temperature-compensated oscillator) with a frequency of 38.4 MHz. The "temperature-compensated" aspect means it is designed to be stable over a wide range of temperatures.  The voltage controlled aspect means that a voltage level is used to cause slight tweaks to the oscillator frequency, and on the bladeRF this voltage is provided by a separate 10-bit digital-to-analog converter (DAC) as shown in green in the block diagram below.  This means through software we can make fine adjustments to the frequency of the oscillator, and this is how we calibrate (a.k.a. trim) the bladeRF's VCTCXO.  Luckily, the bladeRFs are calibrated at the factory, as we discuss later in this section, but if you have the test equipment available you can always fine-tune this value, especially as years go by and the oscillator's frequency drifts.
+У bladeRF встановлено `VCTCXO Abracon <https://abracon.com/Oscillators/ASTX12_ASVTX12.pdf>`_ (керований напругою температурно-компенсований генератор) із частотою 38,4 МГц. «Температурна компенсація» означає, що він розрахований на стабільність у широкому діапазоні температур. Керування напругою означає, що частота генератора може змінюватися залежно від прикладеної напруги, і в bladeRF цю напругу подає окремий 10-бітний цифро-аналоговий перетворювач (DAC), показаний зеленим кольором на блок-схемі нижче. Це дає змогу програмно виконувати тонке підлаштування частоти генератора, і саме так ми калібруємо (тобто підлаштовуємо) VCTCXO bladeRF. На щастя, пристрої bladeRF калібруються на заводі, як ми обговоримо далі, але якщо у вас є відповідне вимірювальне обладнання, ви можете додатково відрегулювати це значення, особливо через роки, коли частота генератора може дрейфувати.
 
 .. image:: ../_images/bladeRF-2.0-micro-Block-Diagram-4-oscillator.png
    :scale: 80 %
-   :align: center 
+   :align: center
    :alt: bladeRF 2.0 glamour shot
 
-When using an external frequency reference (which can be nearly any frequency up to 300 MHz), the reference signal is fed directly into the `Analog Devices ADF4002 <http://www.analog.com/en/adf4002>`_ PLL onboard the bladeRF.  This PLL locks on to the reference signal and sends a signal to the VCTCXO (as shown in blue above) that is proportional to the difference in frequency and phase between the (scaled) reference input and VCTCXO output. Once the PLL is locked, this signal between the PLL and VCTCXO is a steady-state DC voltage that keeps the VCTCXO output at "exactly" 38.4 MHz (assuming the reference was correct), and phase-locked to the reference input.  As part of using an external reference you must enable :code:`clock_ref` (either through Python or the CLI), and set the input reference frequency (a.k.a. :code:`refin_freq`), which is 10 MHz by default.  Reasons to use an external reference include better frequency accuracy, and the ability to synchronize multiple SDRs to the same reference.
+Під час використання зовнішнього частотного еталону (який може мати майже будь-яку частоту до 300 МГц) референсний сигнал подається безпосередньо на PLL `Analog Devices ADF4002 <http://www.analog.com/en/adf4002>`_, що встановлена на bladeRF. Ця PLL захоплює еталонний сигнал і подає на VCTCXO (позначено синім) сигнал, пропорційний різниці частоти та фази між (масштабованим) еталонним входом і виходом VCTCXO. Коли PLL захоплює синхронізм, цей сигнал між PLL і VCTCXO стає стабільною постійною напругою, що підтримує вихід VCTCXO на «точно» 38,4 МГц (за умови, що еталон точний) і фазово синхронізує його з еталонним сигналом. Під час використання зовнішнього еталона потрібно ввімкнути :code:`clock_ref` (через Python або CLI) і задати частоту еталонного входу (:code:`refin_freq`), яка за замовчуванням дорівнює 10 МГц. Причини використовувати зовнішній еталон — це покращена точність частоти та можливість синхронізувати кілька SDR одним еталоном.
 
-Each bladeRF VCTCXO DAC trim value is calibrated at the factory to be within 1 Hz at 38.4 MHz at room temperature, and you can enter your serial number into `this page <https://www.nuand.com/calibration/>`_ to see what the factory calibrated value was (find your serial number on the board or using :code:`bladerf-tool probe`).  A fresh board should be well within 0.5 ppm and likely closer to 0.1 ppm, according to Nuand.  If you have test equipment to measure the frequency accuracy, or want to set it to the factory value, you can use the commands:
+Для кожного bladeRF значення підстроювання VCTCXO DAC калібрується на заводі з точністю до 1 Гц на частоті 38,4 МГц при кімнатній температурі, і ви можете ввести свій серійний номер на `цій сторінці <https://www.nuand.com/calibration/>`_, щоб дізнатися заводське значення (серійний номер вказано на платі або доступний через :code:`bladerf-tool probe`). За словами Nuand, нова плата має точність набагато кращу за 0.5 ppm і, ймовірно, ближче до 0.1 ppm. Якщо у вас є обладнання для вимірювання точності частоти або ви хочете встановити заводське значення, використовуйте команди:
 
 .. code-block:: bash
 
  $ bladeRF-cli -i
  bladeRF> flash_init_cal 301 0x2049
 
-swapping :code:`301` with your bladeRF size and :code:`0x2049` with the hex format of your VCTCXO DAC trim value.  You must power cycle for it to go into effect.
+Замінивши :code:`301` на розмір вашого bladeRF і :code:`0x2049` на шістнадцяткове представлення вашого значення підстроювання VCTCXO DAC. Щоб зміни набули чинності, потрібно перезапустити живлення.
 
 ***********************************
-Sampling at 122 MHz
+Дискретизація на 122 МГц
 ***********************************
 
-Coming Soon!
+Незабаром!
 
 ***********************************
-Expansion Ports
+Порти розширення
 ***********************************
 
-The bladeRF 2.0 includes an expansion port using a BSH-030 connector.  More information on using this port coming soon!
+bladeRF 2.0 містить порт розширення з використанням роз'єма BSH-030. Докладніша інформація про використання цього порту з'явиться пізніше!
 
 ********************************
-Further Reading
+Додаткові матеріали
 ********************************
 
-#. `bladeRF Wiki <https://github.com/Nuand/bladeRF/wiki>`_
-#. `Nuand's txrx.py example <https://github.com/Nuand/bladeRF/blob/master/host/examples/python/txrx/txrx.py>`_
+#. `Wiki bladeRF <https://github.com/Nuand/bladeRF/wiki>`_
+#. `Приклад Nuand txrx.py <https://github.com/Nuand/bladeRF/blob/master/host/examples/python/txrx/txrx.py>`_


### PR DESCRIPTION
## Summary
- translate the bladeRF Python tutorial into Ukrainian while preserving formatting and code samples

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3e11b3f948328af4c863bca0ea1a8