### PR TITLE
Translate cyclostationary chapter into Ukrainian

### DIFF
--- a/content-ukraine/cyclostationary.rst
+++ b/content-ukraine/cyclostationary.rst
@@ -1,86 +1,86 @@
 .. _freq-domain-chapter:
 
 ##########################
-Cyclostationary Processing
+Циклостаціонарна обробка
 ##########################
 
 .. raw:: html
 
- <span style="display: table; margin: 0 auto; font-size: 20px;">Co-authored by <a href="https://www.linkedin.com/in/samuel-brown-vt">Sam Brown</a></span>
+ <span style="display: table; margin: 0 auto; font-size: 20px;">У співавторстві з <a href="https://www.linkedin.com/in/samuel-brown-vt">Sam Brown</a></span>
 
-In this chapter we demystify cyclostationary signal processing (a.k.a. CSP), a relatively niche area of RF signal processing that is used to analyze or detect (often in very low SNR!) signals that exhibit cyclostationary properties, such as most modern digital modulation schemes.  We cover the Cyclic Autocorrelation Function (CAF), Spectral Correlation Function (SCF), Spectral Coherence Function (COH), conjugate versions of these functions, and how they can be applied.  This chapter includes several full Python implementations, with examples that involve BPSK, QPSK, OFDM, and multiple combined signals.
+У цьому розділі ми розкриваємо суть обробки циклостаціонарних сигналів (cyclostationary signal processing, або CSP) — відносно нішової галузі радіочастотної (RF) обробки сигналів, яка використовується для аналізу або виявлення (часто за дуже низького SNR!) сигналів із циклостаціонарними властивостями, зокрема більшості сучасних схем цифрової модуляції.  Ми розглянемо циклічну автокореляційну функцію (CAF), спектральну кореляційну функцію (SCF), функцію спектральної когерентності (COH), їхні спряжені варіанти та способи застосування.  Розділ містить кілька повних реалізацій на Python з прикладами, що охоплюють BPSK, QPSK, OFDM та кілька одночасних сигналів.
 
 ****************
-Introduction
+Вступ
 ****************
 
-Cyclostationary signal processing (a.k.a., CSP or simply cyclostationary processing) is a set of techniques for exploiting the cyclostationary property found in many real-world communication signals. These are signals such as modulated signals like AM/FM/TV broadcast, cellular, and WiFi as well as radar signals, and other signals that exhibit periodicity in their statistics. A large swath of traditional signal processing techniques are based on the assumption that the signal is stationary, i.e., the statistics of the signal like the mean, variance and higher-order moments do not change over time. However, most real-world RF signals are cyclostationary, i.e., the statistics of the signal change *periodically* over time. CSP techniques exploit this cyclostationary property, and can be used to detect the presence of signals in noise, perform modulation recognition, and separate signals that are overlapping in both time and frequency.
+Циклостаціонарна обробка сигналів (CSP або просто циклостаціонарна обробка) — це набір технік, що дозволяє використовувати циклостаціонарну властивість, притаманну багатьом реальним комунікаційним сигналам. Це можуть бути модульовані сигнали, як-от трансляції AM/FM/ТБ, стільниковий та WiFi зв’язок, а також радари й інші сигнали, статистика яких має періодичність. Значна частина класичних методів обробки сигналів ґрунтується на припущенні, що сигнал стаціонарний, тобто його статистики, такі як середнє значення, дисперсія та моменти вищих порядків, не змінюються з часом. Однак більшість реальних RF-сигналів є циклостаціонарними, тобто їхня статистика змінюється *періодично* з часом. Техніки CSP використовують цю циклостаціонарну властивість і можуть застосовуватися для виявлення сигналів у шумі, розпізнавання модуляції та розділення сигналів, що перекриваються як у часі, так і в частоті.
 
-If after reading through this chapter and playing around in Python, you want to dive deeper into CSP, check out William Gardner's 1994 textbook `Cyclostationarity in Communications and Signal Processing <https://faculty.engineering.ucdavis.edu/gardner/wp-content/uploads/sites/146/2014/05/Cyclostationarity.pdf>`_, his 1987 textbook `Statistical Spectral Analysis <https://faculty.engineering.ucdavis.edu/gardner/wp-content/uploads/sites/146/2013/02/Statistical_Spectral_Analysis_A_Nonprobabilistic_Theory.pdf>`_, or Chad Spooner's `collection of blog posts <https://cyclostationary.blog/>`_.
+Якщо після читання цього розділу та експериментів у Python ви захочете глибше зануритися в CSP, перегляньте підручник Вільяма Гарднера 1994 року `Cyclostationarity in Communications and Signal Processing <https://faculty.engineering.ucdavis.edu/gardner/wp-content/uploads/sites/146/2014/05/Cyclostationarity.pdf>`_, його підручник 1987 року `Statistical Spectral Analysis <https://faculty.engineering.ucdavis.edu/gardner/wp-content/uploads/sites/146/2013/02/Statistical_Spectral_Analysis_A_Nonprobabilistic_Theory.pdf>`_, або `збірку публікацій у блозі Чада Спунера <https://cyclostationary.blog/>`_.
 
-One resource that you will find here and in no other textbook: at the end of the SCF chapter you will be rewarded with an interactive JavaScript app that allows you to play around with the SCF of an example signal, to see how the SCF changes with different signal and SCF parameters, all in your browser!  While these interactive demos are free for everyone, they are largely made possible by the support of PySDR's `Patreon <https://www.patreon.com/PySDR>`_ members.
+Ресурс, який ви знайдете лише тут і ні в жодному підручнику: наприкінці розділу про SCF на вас чекає інтерактивний JavaScript-додаток, що дає змогу експериментувати зі SCF прикладного сигналу та спостерігати, як SCF змінюється за різних параметрів сигналу та самої SCF — усе це просто у вашому браузері!  Хоча ці інтерактивні демонстрації безкоштовні для всіх, здебільшого вони стають можливими завдяки підтримці учасників `Patreon PySDR <https://www.patreon.com/PySDR>`_.
 
 *************************
-Review of Autocorrelation
+Огляд автокореляції
 *************************
 
-Even if you think you're familiar with the autocorrelation function, it is worth taking a moment to review it, because it is the foundation of CSP. The autocorrelation function is a measure of the similarity (a.k.a., correlation) between a signal and the time-shifted version of itself.  Intuitively, it represents the degree to which a signal exhibits repetitive behavior.  The autocorrelation of signal :math:`x(t)` is defined as:
+Навіть якщо ви вважаєте, що знайомі з автокореляційною функцією, варто зробити паузу й пригадати її, адже вона лежить в основі CSP. Автокореляційна функція — це міра подібності (кореляції) між сигналом і його копією, зсуненою в часі.  Інтуїтивно вона відображає, наскільки сигнал демонструє повторювану поведінку.  Автокореляція сигналу :math:`x(t)` визначається так:
 
 .. math::
     R_x(\tau) = E[x(t)x^*(t-\tau)]
 
-where :math:`E` is the expectation operator, :math:`\tau` is the time delay,  and :math:`*` is the complex conjugate symbol.  In discrete time, with a limited number of samples, which is what we care about, this becomes:
+де :math:`E` — оператор математичного сподівання, :math:`\tau` — часовий зсув, а :math:`*` позначає комплексне спряження.  У дискретному часі з обмеженою кількістю відліків, що нас і цікавить, маємо:
 
 .. math::
     R_x(\tau) = \frac{1}{N} \sum_{n=-N/2}^{N/2} x\left[ n+\frac{\tau}{2} \right] x^*\left[ n-\frac{\tau}{2} \right]
 
-where :math:`N` is the number of samples in the signal.  
+де :math:`N` — кількість відліків сигналу.
 
-If the signal is periodic in some way, such as a QPSK signal's repeating symbol shape, then the autocorrelation evaluated over a range of tau will also be periodic.  For example, if a QPSK signal has 8 samples per symbol, then when tau is an integer multiple of 8, there will be a much stronger "measure of the similarity" than other values of tau.  The period of the autocorrelation is what we will ultimately be detecting as part of CSP techniques.
+Якщо сигнал має певну періодичність, наприклад періодичну форму символів у QPSK, то автокореляція, обчислена на проміжку різних :math:`\tau`, теж буде періодичною.  Наприклад, якщо QPSK-сигнал має 8 відліків на символ, то для :math:`\tau`, кратних 8, міра «подібності» значно вища, ніж для інших значень :math:`\tau`.  Період автокореляції — це те, що зрештою виявляють методи CSP.
 
 ************************************************
-The Cyclic Autocorrelation Function (CAF)
+Циклічна автокореляційна функція (CAF)
 ************************************************
 
-As discussed in the previous section, we want to find out when there is periodicity in our autocorrelation.  Recall the Fourier transform equation, where if we want to test how strong a certain frequency :math:`f` exists within some arbitrary signal :math:`x(t)`, we can do so with:
+Як зазначено вище, ми прагнемо визначити, чи є періодичність в автокореляції.  Пригадаємо формулу перетворення Фур’є: якщо ми хочемо з’ясувати, наскільки сильно в деякому сигналі :math:`x(t)` присутня певна частота :math:`f`, ми можемо обчислити:
 
 .. math::
     X(f) = \int x(t) e^{-j2\pi ft} dt
 
-So if we want to find periodicity in our autocorrelation, we simply calculate: 
+Тож, щоб знайти періодичність в автокореляції, просто обчислимо:
 
 .. math::
     R_x(\tau, \alpha) = \lim_{T\rightarrow\infty} \frac{1}{T} \int_{-T/2}^{T/2} x(t + \tau/2)x^*(t - \tau/2)e^{-j2\pi \alpha t}dt.
 
-or in discrete time:
+або в дискретному часі:
 
 .. math::
     R_x(\tau, \alpha) = \frac{1}{N} \sum_{n=-N/2}^{N/2} x\left[ n+\frac{\tau}{2} \right] x^*\left[ n-\frac{\tau}{2} \right] e^{-j2\pi \alpha n}
 
-which tests how strong frequency :math:`\alpha` is.  We call the above equation the Cyclic Autocorrelation Function (CAF).  Another way to think about the CAF is as a set of Fourier series coefficients that describe this periodicity. In other words, the CAF is the amplitude and phase of the harmonics present in a signal's autocorrelation.  We use the term "cyclostationary" to refer to signals that possess a periodic or almost periodic autocorrelation.  The CAF is an extension of the traditional autocorrelation function to cyclostationary signals.
+Це дозволяє перевірити, наскільки сильною є частота :math:`\alpha`.  Наведений вище вираз називається циклічною автокореляційною функцією (CAF).  Інший спосіб інтерпретації CAF — це набір коефіцієнтів ряду Фур’є, які описують згадану періодичність.  Іншими словами, CAF — це амплітуда та фаза гармонік, присутніх в автокореляції сигналу.  Ми використовуємо термін «циклостаціонарний», щоб описати сигнали, автокореляція яких є періодичною або майже періодичною.  CAF є розширенням традиційної автокореляційної функції для циклостаціонарних сигналів.
 
-It can be seen that the CAF is a function of two variables, the delay :math:`\tau` (tau) and the cycle frequency :math:`\alpha`. Cycle frequencies in CSP represent the rates at which a signals' statistics change, which in the case of the CAF, is the second-order moment or variance. Therefore, cycle frequencies often correspond to prominent periodic behavior such as modulated symbols in communications signals. We will see how the symbol rate of a BPSK signal and its integer multiples (harmonics) manifest as cycle frequencies in the CAF.
+Видно, що CAF залежить від двох змінних: затримки :math:`\tau` (tau) та циклічної частоти :math:`\alpha`.  Циклічні частоти в CSP відображають швидкість зміни статистики сигналу, що у випадку CAF означає момент другого порядку або дисперсію. Тож циклічні частоти часто відповідають виразним періодичним явищам, таким як символи, що модулюються в комунікаційних сигналах. Побачимо, як символова швидкість сигналу BPSK та її цілі кратні (гармоніки) проявляються як циклічні частоти у CAF.
 
-In Python, the CAF of baseband signal :code:`samples` at a given :code:`alpha` and :code:`tau` value can be computed using the following code snippet (we'll fill out the surrounding code shortly):
+У Python CAF базового сигналу :code:`samples` для заданих :code:`alpha` та :code:`tau` можна обчислити за допомогою такого фрагмента (ми незабаром додамо обрамлювальний код):
 
 .. code-block:: python
- 
+
  CAF = (np.exp(1j * np.pi * alpha * tau) *
-        np.sum(samples * np.conj(np.roll(samples, tau)) * 
+        np.sum(samples * np.conj(np.roll(samples, tau)) *
                np.exp(-2j * np.pi * alpha * np.arange(N))))
 
-We use :code:`np.roll()` to shift one of the sets of samples by tau, because you have to shift by an integer number of samples, so if we shifted both sets of samples in opposite directions we would skip every other shift.  We also have to add a frequency shift to account for the fact that we're shifting by 1 sample at a time, and only on one side (instead of half a sample on both sides like the basic CAF equation).  The frequency of the shift is :code:`alpha/2`.
+Ми використовуємо :code:`np.roll()` для зсуву одного набору відліків на :code:`tau`, адже потрібно зміщувати на ціле число відліків.  Якби ми зсували обидва набори у протилежних напрямках, ми пропускали б кожне друге зміщення.  Також необхідно додати частотний зсув, щоб компенсувати те, що ми зміщуємо на 1 відлік за раз і лише з одного боку (замість половини відліку в обидва боки, як у базовому рівнянні CAF).  Частота цього зсуву дорівнює :code:`alpha/2`.
 
-In order to play with the CAF in Python, we first need to simulate an example signal. For now we will use a rectangular BPSK signal (i.e., BPSK without pulse-shaping applied) with 20 samples per symbol, added to some white Gaussian noise (AWGN).  We will apply a frequency offset to the BPSK signal, so that later we can show off how cyclostationary processing can be used to estimate the frequency offset as well as the cyclic frequency.  This frequency offset is equivalent to your radio receiving a signal while not perfectly centered on it; either a little off or way off (but not too much to cause the signal to extend past the sampled bandwidth).
+Щоб погратися з CAF у Python, спершу змоделюємо приклад сигналу. Поки що використаємо прямокутний сигнал BPSK (тобто BPSK без формування імпульсу) з 20 відліками на символ та додамо білий гаусів шум (AWGN).  Ми навмисне внесемо частотний зсув у сигнал BPSK, аби пізніше продемонструвати, як циклостаціонарна обробка допомагає оцінювати і частотний зсув, і циклічну частоту.  Цей зсув відповідає ситуації, коли приймач не ідеально налаштований на частоту сигналу: або трохи хибить, або суттєво, але не настільки, щоб сигнал виходив за межі смуги дискретизації.
 
-The following code snippet simulates the IQ samples we will use for the remainder of the next two sections:
+Наведений нижче код генерує IQ-відліки, які ми використовуватимемо впродовж двох наступних розділів:
 
 .. code-block:: python
 
  N = 100000 # number of samples to simulate
  f_offset = 0.2 # Hz normalized
  sps = 20 # cyclic freq (alpha) will be 1/sps or 0.05 Hz normalized
- 
+
  symbols = np.random.randint(0, 2, int(np.ceil(N/sps))) * 2 - 1 # random 1's and -1's
  bpsk = np.repeat(symbols, sps)  # repeat each symbol sps times to make rectangular BPSK
  bpsk = bpsk[:N]  # clip off the extra samples
@@ -88,18 +88,18 @@ The following code snippet simulates the IQ samples we will use for the remainde
  noise = np.random.randn(N) + 1j*np.random.randn(N) # complex white Gaussian noise
  samples = bpsk + 0.1*noise  # add noise to the signal
 
-Because the absolute sample rate and symbol rate doesn't really matter anywhere in this chapter, we will use normalized frequency, which is effectively the same as saying our sample rate = 1 Hz.  This means the signal must be between -0.5 to +0.5 Hz.  Regardless, you *won't* see the variable :code:`sample_rate` show up in any of the code snippets, on purpose, instead we will work with samples per symbol (:code:`sps`).
+Оскільки абсолютні швидкість дискретизації та швидкість символів у цьому розділі не відіграють ролі, ми використовуємо нормалізовані частоти, що еквівалентно припущенню, що частота дискретизації = 1 Гц.  Це означає, що сигнал мусить лежати в діапазоні від -0.5 до +0.5 Гц.  Тому ви *не* побачите змінної :code:`sample_rate` у коді: ми працюємо через кількість відліків на символ (:code:`sps`).
 
-Just for fun, let's look at the power spectral density (i.e., FFT) of the signal itself, *before* any CSP is performed:
+Для розігріву погляньмо на щільність спектральної потужності (PSD, тобто FFT) сигналу до будь-якої обробки CSP:
 
 .. image:: ../_images/psd_of_bpsk_used_for_caf.svg
-   :align: center 
+   :align: center
    :target: ../_images/psd_of_bpsk_used_for_caf.svg
-   :alt: PSD of BPSK used for CAF
+   :alt: PSD прямокутного сигналу BPSK, що використовується для CAF
 
-It has the 0.2 Hz frequency shift that we applied, and the samples per symbol of 20 leads to a fairly narrow signal, but because we did not apply pulse shaping, the signal tapers off very slowly in frequency.
+На графіку видно частотний зсув 0.2 Гц, який ми додали, і те, що 20 відліків на символ формують доволі вузький сигнал, але через відсутність формування імпульсу спектр спадає дуже повільно.
 
-Now we will compute the CAF at the correct alpha, and over a range of tau values (we'll use tau from -50 to +50 as a starting point).  The correct alpha in our case is simply the samples per symbol inverted, or 1/20 = 0.05 Hz.  To generate the CAF in Python, we will loop over tau:
+Тепер обчислимо CAF для правильного :math:`\alpha` та діапазону :math:`\tau` (візьмемо від -50 до +50).  Правильне :math:`\alpha` у нашому випадку — це обернена величина кількості відліків на символ, тобто 1/20 = 0.05 Гц.  Щоб отримати CAF у Python, проітеруємося за :math:`\tau`:
 
 .. code-block:: python
 
@@ -109,26 +109,26 @@ Now we will compute the CAF at the correct alpha, and over a range of tau values
     CAF = np.zeros(len(taus), dtype=complex)
     for i in range(len(taus)):
         CAF[i] = (np.exp(1j * np.pi * alpha_of_interest * taus[i]) * # This term is to make up for the fact we're shifting by 1 sample at a time, and only on one side
-                  np.sum(samples * np.conj(np.roll(samples, taus[i])) * 
+                  np.sum(samples * np.conj(np.roll(samples, taus[i])) *
                          np.exp(-2j * np.pi * alpha_of_interest * np.arange(N))))
 
-Let's plot the real part of :code:`CAF` using :code:`plt.plot(taus, np.real(CAF))`:
+Побудуємо дійсну частину :code:`CAF` за допомогою :code:`plt.plot(taus, np.real(CAF))`:
 
 .. image:: ../_images/caf_at_correct_alpha.svg
-   :align: center 
+   :align: center
    :target: ../_images/caf_at_correct_alpha.svg
-   :alt: CAF at correct alpha
+   :alt: CAF для правильного значення alpha
 
-It looks a little funny, but keep in mind that tau represents the time domain, and the important part is that there is a lot of energy in the CAF at this alpha, because it's the alpha corresponding to a cyclic frequency within our signal.  To prove this, let's look at the CAF at an incorrect alpha, say 0.08 Hz:
+Вигляд трохи дивний, але зважайте, що :math:`\tau` представляє часову вісь, а найважливіше — велика енергія CAF для цього :math:`\alpha`, адже воно відповідає циклічній частоті нашого сигналу.  Щоб переконатися, розгляньмо CAF для «неправильного» :math:`\alpha`, скажімо 0.08 Гц:
 
 .. image:: ../_images/caf_at_incorrect_alpha.svg
-   :align: center 
+   :align: center
    :target: ../_images/caf_at_incorrect_alpha.svg
-   :alt: CAF at incorrect alpha
+   :alt: CAF для неправильного значення alpha
 
-Note the y-axis, there is way less energy in the CAF this time.  The specific patterns we see above are less important at the moment, and will make more sense after we study the SCF in the next section.
+Зверніть увагу на вісь Y — енергії CAF тепер значно менше.  Конкретні шаблони поки не такі важливі; вони стануть зрозумілішими після вивчення SCF у наступному розділі.
 
-One thing we can do is calculate the CAF over a range of alphas, and at each alpha we can find the power in the CAF, by taking its magnitude and taking either the sum or average (doesn't make a difference in this case).  Then if we plot these powers over alpha, we should see spikes at the cyclic frequencies within our signal.  The following code adds a :code:`for` loop, and uses an alpha step size of 0.005 Hz (note that this will take a long time to run!):
+Ще один підхід — обчислити CAF у діапазоні :math:`\alpha`, а для кожного :math:`\alpha` знайти потужність CAF, взявши модуль і суму (або середнє — тут не суттєво).  Потім, якщо побудувати цю потужність залежно від :math:`\alpha`, побачимо сплески на циклічних частотах сигналу.  Наступний код додає цикл :code:`for` та використовує крок :math:`\alpha` 0.005 Гц (зверніть увагу, що виконання триватиме довго!):
 
 .. code-block:: python
 
@@ -137,7 +137,7 @@ One thing we can do is calculate the CAF over a range of alphas, and at each alp
     for j in range(len(alphas)):
         for i in range(len(taus)):
             CAF[j, i] = (np.exp(1j * np.pi * alphas[j] * taus[i]) *
-                         np.sum(samples * np.conj(np.roll(samples, taus[i])) * 
+                         np.sum(samples * np.conj(np.roll(samples, taus[i])) *
                                 np.exp(-2j * np.pi * alphas[j] * np.arange(N))))
     CAF_magnitudes = np.average(np.abs(CAF), axis=1) # at each alpha, calc power in the CAF
     plt.plot(alphas, CAF_magnitudes)
@@ -145,21 +145,21 @@ One thing we can do is calculate the CAF over a range of alphas, and at each alp
     plt.ylabel('CAF Power')
 
 .. image:: ../_images/caf_avg_over_alpha.svg
-   :align: center 
+   :align: center
    :target: ../_images/caf_avg_over_alpha.svg
-   :alt: CAF average over alpha
+   :alt: Середня потужність CAF залежно від alpha
 
-Not only do we see the expected spike at 0.05 Hz, but we also see a spike at integer multiples of 0.05 Hz.  This is because the CAF is a Fourier series, and the harmonics of the fundamental frequency are present in the CAF, especially when we are looking at PSK/QAM signals without pulse shaping.  The energy at alpha = 0 is the total power in the power spectral density (PSD) of the signal, although we will typically null it out because 1) we often plot the PSD on its own and 2) it will throw off the dynamic range of our colormap when we start plotting 2D data with a colormap.
+Бачимо очікуваний пік на 0.05 Гц, а також на цілих кратних 0.05 Гц.  Це тому, що CAF — це ряд Фур’є, і гармоніки основної частоти присутні в CAF, особливо для PSK/QAM без формування імпульсу.  Енергія на :math:`\alpha = 0` відповідає загальній потужності у PSD сигналу, хоча зазвичай ми її занулюємо, адже 1) PSD часто будують окремо і 2) вона псує динамічний діапазон колірної карти, коли ми починаємо відображати 2D-дані.
 
-While the CAF is interesting, we often want to view cyclic frequency *over RF frequency*, instead of just cyclic frequency on its own like we see above.  This leads us to the Spectral Correlation Function (SCF), which we will discuss next.
+Хоч CAF цікавий, зазвичай нам хочеться побачити циклічну частоту *як функцію RF-частоти*, а не лише циклічну частоту, як у графіку вище.  Це приводить нас до спектральної кореляційної функції (SCF), яку розглянемо далі.
 
 ************************************************
-The Spectral Correlation Function (SCF)
+Спектральна кореляційна функція (SCF)
 ************************************************
 
-Just as the CAF shows us the periodicity in the autocorrelation of a signal, the SCF shows us the periodicity in the PSD of a signal. The autocorrelation and the PSD are in fact a Fourier transform pair, and therefore it should not come as a surprise that the CAF and the SCF are also a Fourier Transform pair. This relationship is known as the *Cyclic Wiener Relationship*. This fact should make even more sense when one considers that the CAF and SCF evaluated at a cycle frequency of :math:`\alpha=0` are the autocorrelation and PSD, respectively.
+Подібно до того, як CAF показує періодичність в автокореляції сигналу, SCF демонструє періодичність у PSD сигналу. Автокореляція та PSD є парою перетворення Фур’є, тож не дивно, що CAF і SCF також є парою перетворення Фур’є. Це співвідношення називають *циклічним співвідношенням Вінера* (Cyclic Wiener Relationship). Воно стає ще зрозумілішим, якщо згадати, що CAF і SCF при :math:`\alpha = 0` відповідають автокореляції та PSD відповідно.
 
-One can simply take the Fourier transform of the CAF to obtain the SCF.  Returning to our 20 sample-per-symbol BPSK signal, let's look at the SCF at the correct alpha (0.05 Hz). All we need to do is take the FFT of the CAF and plot the magnitude. The following code snippet goes along with the CAF code we wrote earlier when computing just one alpha:
+SCF можна отримати простим перетворенням Фур’є CAF.  Повернімося до нашого BPSK із 20 відліками на символ і розгляньмо SCF для правильного :math:`\alpha` (0.05 Гц). Все, що треба, — взяти FFT від CAF та побудувати модуль. Наведений нижче код доповнює попередній приклад, де ми обчислювали одне значення :math:`\alpha`:
 
 .. code-block:: python
 
@@ -170,15 +170,15 @@ One can simply take the Fourier transform of the CAF to obtain the SCF.  Returni
  plt.ylabel('SCF')
 
 .. image:: ../_images/fft_of_caf.svg
-   :align: center 
+   :align: center
    :target: ../_images/fft_of_caf.svg
-   :alt: FFT of CAF
+   :alt: FFT від CAF
 
-Note that we can see the 0.2 Hz frequency offset that we applied when simulating the BPSK signal (this has nothing to do with the cyclic frequency or samples per symbol).  This is why the CAF looked sinusoidal in the tau domain; it was primarily the RF frequency which in our example was relatively high.
+Зверніть увагу, що видно частотний зсув 0.2 Гц, який ми внесли під час симуляції BPSK (він не пов’язаний із циклічною частотою чи кількістю відліків на символ).  Саме тому CAF у часовій області виглядав синусоїдальним — домінувала RF-частота, яка у нашому прикладі досить висока.
 
-Unfortunately, doing this for thousands or millions of alphas is extremely computationally intensive.  The other downside of just taking the FFT of the CAF is it does not involve any averaging. Efficient/practical computing of the SCF usually involves some form of averaging; either time-based or frequency-based, as we will discuss in the next two sections.
+На жаль, повторювати цю операцію для тисяч або мільйонів :math:`\alpha` надзвичайно витратно обчислювально.  Інший недолік простого FFT від CAF — відсутність усереднення. Практичні алгоритми обчислення SCF зазвичай включають певне усереднення — за часом або частотою, як ми побачимо у двох наступних розділах.
 
-Below is an interactive JavaScript app that implements an SCF, so that you can play around with different signal and SCF parameters to build your intuition.  The frequency of the signal is a fairly straightforward knob, and shows how well the SCF can identify RF frequency.  Try adding pulse shaping by unchecking the Rectangular Pulse option, and play around with different roll-off values.  Note that using the default alpha-step, not all samples per symbols will lead to a visible spike in the SCF.  You can try lowering alpha-step, although it will increase the processing time. 
+Нижче наведено інтерактивний JavaScript-додаток, що реалізує SCF та дозволяє експериментувати з різними параметрами сигналу і SCF, формуючи інтуїцію.  Частота сигналу — доволі очевидний регулятор, він показує, наскільки добре SCF може визначити RF-частоту.  Спробуйте вимкнути прямокутні імпульси (Rectangular Pulse) і попрацювати з різними коефіцієнтами згладжування (roll-off).  Зауважте, що з типовим кроком по :math:`\alpha` не всі значення відліків на символ призведуть до видимого піку в SCF.  Ви можете зменшити крок, але це збільшить час обробки.
 
 .. raw:: html
 
@@ -232,34 +232,34 @@ Below is an interactive JavaScript app that implements an SCF, so that you can p
 
 
 ********************************
-Frequency Smoothing Method (FSM)
+Метод згладжування за частотою (FSM)
 ********************************
 
-Now that we have a good conceptual understanding of the SCF, let's look at how we can compute it efficiently.  First, consider the periodogram which is simply the squared magnitude of the Fourier transform of a signal:
+Тепер, коли ми маємо гарне інтуїтивне уявлення про SCF, розгляньмо, як обчислити її ефективно.  Спершу пригадаємо періодограму — квадрат модуля перетворення Фур’є сигналу:
 
 .. math::
 
  I(u,f) = \frac{1}{N}\left|X(u,f)\right|^2
- 
-We can obtain the cyclic periodogram through the product of two Fourier transforms shifted in frequency:
+
+Циклічну періодограму можна отримати, перемноживши два спектри Фур’є, зсунуті за частотою:
 
 .. math::
 
  I(u,f,\alpha) = \frac{1}{N}X(u,f + \alpha/2) X^*(u,f - \alpha/2)
 
-Both of these represent estimates of the PSD and the SCF, but to obtain the true value of the SCF one must average over either time or frequency.  Averaging over time is known as the Time Smoothing Method (TSM):
+Обидва вирази є оцінками PSD та SCF, але щоб отримати істинне значення SCF, потрібно усереднити або за часом, або за частотою.  Усереднення за часом відоме як метод згладжування за часом (TSM):
 
 .. math::
     S_X(f, \alpha) = \lim_{T\rightarrow\infty} \frac{1}{T} \lim_{U\rightarrow\infty} \frac{1}{U} \int_{-U/2}^{U/2} X(t,f + \alpha/2) X^*(t,f - \alpha/2) dt
 
-while averaging over frequency is known as the Frequency Smoothing Method (FSM):
+а усереднення за частотою називається методом згладжування за частотою (FSM):
 
 .. math::
     S_X(f, \alpha) = \lim_{\Delta\rightarrow 0} \lim_{T\rightarrow \infty} \frac{1}{T} g_{\Delta}(f) \otimes \left[X(t,f + \alpha/2) X^*(t,f - \alpha/2)\right]
 
-where the function :math:`g_{\Delta}(f)` is a frequency smoothing function that averages over a small range of frequencies. 
+де функція :math:`g_{\Delta}(f)` виконує згладжування за невеликим діапазоном частот.
 
-Below is a minimal Python implementation of the FSM, which is a frequency-based averaging method for calculating the SCF of a signal.  First it computes the cyclic periodogram by multiplying two shifted versions of the FFT, and then each slice is filtered with a window function whose length determines the resolution of the resulting SCF estimate. So, longer windows will produce smoother results with lower resolution while shorter ones will do the opposite.
+Нижче наведено мінімальну реалізацію FSM на Python — частотно-орієнтований метод усереднення для обчислення SCF сигналу.  Спершу обчислюється циклічна періодограма через множення двох зсунених FFT, а потім кожен зріз фільтрується вікном, довжина якого визначає роздільну здатність отриманої оцінки SCF. Отже, довші вікна дають більш згладжений результат із нижчою роздільністю, коротші — навпаки.
 
 .. code-block:: python
 
@@ -269,7 +269,7 @@ Below is a minimal Python implementation of the FSM, which is a frequency-based 
     window = np.hanning(Nw)
 
     X = np.fft.fftshift(np.fft.fft(samples)) # FFT of entire signal
-    
+
     num_freqs = int(np.ceil(N/Nw)) # freq resolution after decimation
     SCF = np.zeros((len(alphas), num_freqs), dtype=complex)
     for i in range(len(alphas)):
@@ -285,20 +285,20 @@ Below is a minimal Python implementation of the FSM, which is a frequency-based 
     plt.ylabel('Cyclic Frequency [Normalized Hz]')
     plt.show()
 
-Let's calculate the SCF for the rectangular BPSK signal we used before, with 20 samples per symbol over a range of cyclic frequencies from 0 to 0.3 using a 0.001 step size:
+Обчислимо SCF для прямокутного BPSK, який ми використовували раніше, із 20 відліками на символ, у діапазоні циклічних частот від 0 до 0.3 з кроком 0.001:
 
 .. image:: ../_images/scf_freq_smoothing.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_freq_smoothing.svg
-   :alt: SCF with the Frequency Smoothing Method (FSM), showing cyclostationary signal processing
+   :alt: SCF, обчислена методом згладжування за частотою (FSM)
 
-This method has the advantage that only one large FFT is required, but it also has the disadvantage that many convolution operations are required for the smoothing.  Note the decimation that occurs after the convolve using :code:`[::Nw]`; this is optional but highly recommended to reduce the number of pixels you'll ultimately need to display, and because of the way the SCF is calculated we're not "throwing away" information by decimating by :code:`Nw`.
+Цей метод вимагає лише одного великого FFT, але потребує численних операцій згортки для згладжування.  Зверніть увагу на проріджування після згортки :code:`[::Nw]`; воно не обов’язкове, але дуже бажане, щоб зменшити кількість пікселів для відображення, і завдяки способу обчислення SCF ми не «викидаємо» інформацію, проріджуючи на :code:`Nw`.
 
 ***************************
-Time Smoothing Method (TSM)
+Метод згладжування за часом (TSM)
 ***************************
 
-Next we will look at an implementation of the TSM in Python. The code snippet below divides the signal into *num_windows* blocks, each of length *Nw* with an overlap of *Noverlap*.  Note that the overlap functionality is not required, but tends to help make a nicer output.  The signal is then multiplied by a window function (in this case, Hanning, but it can be any window) and the FFT is taken. The SCF is then calculated by averaging the result from each block. The window length plays the same exact role as in the FSM determining the resolution/smoothness trade-off.
+Далі розглянемо реалізацію TSM у Python. Наведений нижче код ділить сигнал на *num_windows* блоків, кожен довжини *Nw* з перекриттям *Noverlap*.  Зверніть увагу, що перекриття не є обов’язковим, але зазвичай дає приємніший результат.  Сигнал множиться на віконну функцію (у цьому прикладі — вікно Ганна, але можна використовувати будь-яке) і береться FFT.  Потім SCF обчислюється шляхом усереднення результатів для кожного блоку.  Довжина вікна відіграє таку саму роль, як і в FSM, визначаючи компроміс між роздільністю та згладженістю.
 
 
 .. code-block:: python
@@ -329,33 +329,33 @@ Next we will look at an implementation of the TSM in Python. The code snippet be
     plt.show()
 
 .. image:: ../_images/scf_time_smoothing.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_time_smoothing.svg
-   :alt: SCF with the Time Smoothing Method (TSM), showing cyclostationary signal processing
+   :alt: SCF, обчислена методом згладжування за часом (TSM)
 
-Looks roughly the same as the FSM!
+Результат дуже схожий на FSM!
 
 *****************
-Pulse-Shaped BPSK
+BPSK із формуванням імпульсу
 *****************
 
-Up until this point, we have only investigated CSP of a *rectangular* BPSK signal.  However, in actual RF systems, we almost never see rectangular pulses, with the one exception being the BPSK chipping sequence within direct-sequence spread spectrum (DSSS) which tends to be approximately rectangular.  
+Досі ми розглядали CSP лише для *прямокутного* сигналу BPSK.  Проте в реальних RF-системах майже ніколи не зустрінеш прямокутних імпульсів (виняток — чипова послідовність BPSK у DSSS, яка приблизно прямокутна).
 
-Let's now look at a BPSK signal with a raised-cosine (RC) pulse shape, which is a common pulse shape used in digital communications, and is used to reduce the occupied bandwidth of the signal compared to rectangular BPSK.  As discussed in the :ref:`pulse-shaping-chapter` chapter, the RC pulse shape in the time domain is given by:
+Розгляньмо тепер сигнал BPSK із формуванням імпульсу за допомогою фільтра з піднятим косинусом (raised-cosine, RC) — це поширений варіант у цифрових системах, що дозволяє зменшити зайняту смугу порівняно з прямокутним BPSK.  Як пояснюється в розділі :ref:`pulse-shaping-chapter`, RC-імпульс у часовій області описується:
 
 .. math::
  h(t) = \mathrm{sinc}\left( \frac{t}{T} \right) \frac{\cos\left(\frac{\pi\beta t}{T}\right)}{1 - \left( \frac{2 \beta t}{T}   \right)^2}
 
-The :math:`\beta` parameter determines how quickly the filter tapers off in the time domain, which will be inversely proportional with how quickly it tapers off in frequency:
+Параметр :math:`\beta` визначає, наскільки швидко фільтр спадає в часі, що обернено пропорційно швидкості спадання у частоті:
 
 .. image:: ../_images/raised_cosine_freq.svg
-   :align: center 
+   :align: center
    :target: ../_images/raised_cosine_freq.svg
-   :alt: The raised cosine filter in the frequency domain with a variety of roll-off values
+   :alt: Частотна характеристика фільтра з піднятим косинусом для різних коефіцієнтів roll-off
 
-Note that :math:`\beta=0` corresponds to an infinitely long pulse shape and thus is not practical.  Also note that :math:`\beta=1` does *not* correspond to a rectangular pulse shape.  The roll-off factor is typically chosen to be between 0.2 and 0.4 in practice.
+Зверніть увагу: :math:`\beta=0` відповідає нескінченно довгому імпульсу, тож такий варіант непрактичний.  Також :math:`\beta=1` *не* означає прямокутний імпульс.  На практиці коефіцієнт roll-off зазвичай вибирають у діапазоні 0.2–0.4.
 
-We can simulate a BPSK signal with a raised-cosine pulse shaping using the following code snippet; note the first 5 lines and last 4 lines are the same as rectangular BPSK:
+Змоделювати сигнал BPSK із формуванням імпульсу RC можна наступним кодом; зауважте, що перші 5 рядків і останні 4 — ті самі, що й для прямокутного BPSK:
 
 .. code-block:: python
 
@@ -375,13 +375,13 @@ We can simulate a BPSK signal with a raised-cosine pulse shaping using the follo
     t = np.arange(num_taps) - (num_taps-1)//2
     h = np.sinc(t/sps) * np.cos(np.pi*beta*t/sps) / (1 - (2*beta*t/sps)**2) # RC equation
     bpsk = np.convolve(pulse_train, h, 'same') # apply the pulse shaping
-    
+
     bpsk = bpsk[:N]  # clip off the extra samples
     bpsk = bpsk * np.exp(2j * np.pi * f_offset * np.arange(N)) # Freq shift up the BPSK, this is also what makes it complex
     noise = np.random.randn(N) + 1j*np.random.randn(N) # complex white Gaussian noise
     samples = bpsk + 0.1*noise  # add noise to the signal
 
-Note that :code:`pulse_train` is simply our symbols with :code:`sps - 1` zeros after each one, in sequence, e.g.:
+Змінна :code:`pulse_train` — це наші символи, між якими вставлено :code:`sps - 1` нулів, напр.:
 
 .. code-block:: bash
 
@@ -390,70 +390,70 @@ Note that :code:`pulse_train` is simply our symbols with :code:`sps - 1` zeros a
    0  0  0  0  0  0  0  0  0  0  0  0  1  0  0  0  0  0  0  0  0  0  0  0
    0  0  0  0  0  0  0  0 -1  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0...
 
-The plot below shows the pulse-shaped BPSK in the time domain, before noise, and before the frequency shift is added:
+Нижче показано сигнал BPSK із формуванням імпульсу в часовій області, до додавання шуму і частотного зсуву:
 
 .. image:: ../_images/pulse_shaped_BSPK.svg
-   :align: center 
+   :align: center
    :target: ../_images/pulse_shaped_BSPK.svg
-   :alt: Pulse-shaped BPSK signal with a raised-cosine pulse shape
+   :alt: Сигнал BPSK із формуванням імпульсу RC
 
-Now let's calculate the SCF of this pulse-shaped BPSK signal with a roll-off of 0.3, 0.6, and 0.9. We will use the same frequency shift of 0.2 Hz, and the FSM implementation, with the same FSM parameters and symbol length as used in the rectangular BPSK example, to make it a fair comparison:
+Обчислимо SCF цього сигналу з коефіцієнтом roll-off 0.3, 0.6 та 0.9. Використаємо той самий частотний зсув 0.2 Гц і реалізацію FSM з тими самими параметрами, що й у прикладі з прямокутним BPSK, для чесного порівняння:
 
 :code:`beta = 0.3`:
 
 .. image:: ../_images/scf_freq_smoothing_pulse_shaped_bpsk.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_freq_smoothing_pulse_shaped_bpsk.svg
-   :alt: SCF of pulse-shaped BPSK using the Frequency Smoothing Method (FSM) beta 0.3
+   :alt: SCF сигналу BPSK із формуванням імпульсу (FSM), beta = 0.3
 
 :code:`beta = 0.6`:
 
 .. image:: ../_images/scf_freq_smoothing_pulse_shaped_bpsk2.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_freq_smoothing_pulse_shaped_bpsk2.svg
-   :alt: SCF of pulse-shaped BPSK using the Frequency Smoothing Method (FSM) beta 0.6
+   :alt: SCF сигналу BPSK із формуванням імпульсу (FSM), beta = 0.6
 
 :code:`beta = 0.9`:
 
 .. image:: ../_images/scf_freq_smoothing_pulse_shaped_bpsk3.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_freq_smoothing_pulse_shaped_bpsk3.svg
-   :alt: SCF of pulse-shaped BPSK using the Frequency Smoothing Method (FSM) beta 0.9
+   :alt: SCF сигналу BPSK із формуванням імпульсу (FSM), beta = 0.9
 
-In all three, we no longer get the sidelobes in the frequency axis, and in the cyclic frequency axis we don't get the same powerful harmonics of the fundamental cyclic frequency.  This is because the raised-cosine pulse shape has a much better spectral containment than the rectangular pulse shape, and the sidelobes are much lower.  As a result, pulse-shaped signals tend to have a much "cleaner" SCF than rectangular signals, resembling a single spike with a smearing above it.  This will apply to all single carrier digitally modulated signals, not just BPSK.  As beta gets larger we get a broader spike in the frequency axis because the signal takes up more bandwidth.
-
-********************************
-SNR and Number of Symbols
-********************************
-
-Coming Soon!  We will cover how at a certain point, higher SNR doesn't help, and instead you need more symbols, and how packet-based waveforms will lead to a limited number of symbols per transmission.
+В усіх трьох випадках ми більше не бачимо бічних пелюсток на осі частоти, а на осі циклічної частоти відсутні потужні гармоніки базової циклічної частоти.  Це тому, що RC-фільтр забезпечує набагато краще обмеження спектра порівняно з прямокутними імпульсами, тож бічні пелюстки значно слабші.  У результаті сигнали з формуванням імпульсу мають набагато «чистішу» SCF, схожу на один пік із розмиттям над ним.  Це стосується всіх одноносійних цифрових сигналів, не лише BPSK.  Зі збільшенням :math:`\beta` пік на осі частоти розширюється, оскільки сигнал займає більшу смугу.
 
 ********************************
-QPSK and Higher-Order Modulation
+SNR та кількість символів
 ********************************
 
-Coming Soon! It will include QPSK, higher order PSK, QAM, and a brief intro into higher-order cyclic moments and cumulants.
+Незабаром!  Ми розглянемо, чому після певного порогу збільшення SNR не допомагає — натомість потрібна більша кількість символів, і як пакетні хвилі призводять до обмеженої кількості символів у передачі.
 
 ********************************
-Multiple Overlapping Signals
+QPSK та модуляції вищих порядків
 ********************************
 
-Up until now we have only looked at one signal at a time, but what if our received signal contains multiple individual signals that overlap in frequency, time, and even cyclic frequency (i.e., have the same samples per symbol)?  If signals don't overlap in frequency at all, you can use simple filtering to separate them, and a PSD to detect them, assuming they are above the noise floor.  If they don't overlap in time, then you can detect the rising and falling edge of each transmission, then use time-gating to separate the signal processing of each one.  In CSP we are often focused on detecting the presence of signals at different cyclic frequencies that overlap in both time and frequency. 
+Незабаром! У розділі буде QPSK, вищі порядки PSK, QAM та короткий вступ до циклічних моментів і кумулянтів вищих порядків.
 
-Let's simulate three signals, each with different properties:
+********************************
+Кілька перекривних сигналів
+********************************
 
-* Signal 1: Rectangular BPSK with 20 samples per symbol and 0.2 Hz frequency offset
-* Signal 2: Pulse-shaped BPSK with 20 samples per symbol, -0.1 Hz frequency offset, and 0.35 roll-off
-* Signal 3: Pulse-shaped QPSK with 4 samples per symbol, 0.2 Hz frequency offset, and 0.21 roll-off
+Досі ми розглядали по одному сигналу, але що, якщо в отриманому сигналі одночасно присутні кілька сигналів, які перекриваються за частотою, часом і навіть циклічною частотою (тобто мають однакову кількість відліків на символ)?  Якщо сигнали зовсім не перекриваються в частоті, можна застосувати просте фільтрування та PSD для їх виявлення (за умови, що вони вище шумового порога).  Якщо вони не перекриваються в часі, можна визначити моменти увімкнення/вимкнення кожної передачі й обробляти кожну окремо.  У CSP нас зазвичай цікавить виявлення сигналів на різних циклічних частотах, які перекриваються одночасно і за часом, і за частотою.
 
-As you can see, we have two signals that have the same cyclic frequency, and two with the same RF frequency.  This will let us experiment with different degrees of parameter overlap.
+Змоделюємо три сигнали з різними властивостями:
 
-A fractional delay filter with an arbitrary (non-integer) delay is applied to each signal, so that there are no weird artifacts caused by the signals being simulated with aligned samples (learn more about this in the :ref:`sync-chapter` chapter).  The rectangular BPSK signal is reduced in power compared to the other two, as rectangular-pulsed signals exhibit very strong cyclostationary properties so they tend to dominate the SCF.
+* Сигнал 1: прямокутний BPSK із 20 відліками на символ і частотним зсувом 0.2 Гц
+* Сигнал 2: BPSK із формуванням імпульсу, 20 відліків на символ, частотний зсув -0.1 Гц, коефіцієнт roll-off 0.35
+* Сигнал 3: QPSK із формуванням імпульсу, 4 відліки на символ, частотний зсув 0.2 Гц, коефіцієнт roll-off 0.21
+
+Отже, маємо два сигнали з однаковою циклічною частотою та два — з однаковою RF-частотою.  Це дозволить дослідити різні ступені перекриття параметрів.
+
+До кожного сигналу додається фільтр дробової затримки з довільною (нецілою) затримкою, щоб уникнути артефактів, пов’язаних із синхронним розташуванням відліків (докладніше про це в розділі :ref:`sync-chapter`).  Потужність прямокутного BPSK зменшено порівняно з двома іншими, оскільки сигнали з прямокутними імпульсами мають дуже виражені циклостаціонарні властивості й схильні домінувати в SCF.
 
 .. raw:: html
 
    <details>
-   <summary>Expand for Python code simulating the three signals</summary>
+   <summary>Показати код Python для симуляції трьох сигналів</summary>
 
 .. code-block:: python
 
@@ -510,29 +510,29 @@ A fractional delay filter with an arbitrary (non-integer) delay is applied to ea
 
    </details>
 
-Before we dive into the CSP, let's look at the PSD of this signal:
+Перш ніж перейти до CSP, подивімося на PSD цього сигналу:
 
 .. image:: ../_images/psd_of_multiple_signals.svg
-   :align: center 
+   :align: center
    :target: ../_images/psd_of_multiple_signals.svg
-   :alt: PSD of three different signals
+   :alt: PSD трьох різних сигналів
 
-Signals 1 and 3, which are on the positive side of the PSD, overlap and you can barely see Signal 1 (which is narrower) sticking out.  We can also get a feel for the noise level.
+Сигнали 1 і 3, розташовані на додатній частоті, перекриваються, і вузький сигнал 1 ледве виглядає.  Також за графіком видно рівень шуму.
 
-We will now use the FSM to calculate the SCF of these combined signals:
+Тепер використаємо FSM для обчислення SCF суми цих сигналів:
 
 .. image:: ../_images/scf_freq_smoothing_pulse_multiple_signals.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_freq_smoothing_pulse_multiple_signals.svg
-   :alt: SCF of three different signals using the Frequency Smoothing Method (FSM)
+   :alt: SCF трьох сигналів, обчислена методом згладжування за частотою (FSM)
 
-Notice how Signal 1, even though it's rectangular pulse-shaped, has its harmonics mostly masked by the cone above Signal 3.  Recall that in the PSD, Signal 1 was "hiding behind" Signal 3.  Through CSP, we can detect that Signal 1 is present, and get a close approximation of its cyclic frequency, which can then be used to synchronize to it.  This is the power of cyclostationary signal processing!
+Зауважте, що сигнал 1, хоч і з прямокутними імпульсами, переважно маскується «конусом» над сигналом 3.  На PSD сигнал 1 «ховався» за сигналом 3.  Завдяки CSP ми можемо виявити присутність сигналу 1 та приблизно визначити його циклічну частоту, яку потім можна використати для синхронізації.  Ось у чому сила циклостаціонарної обробки!
 
 ************************
-Alternative CSP Features
+Альтернативні ознаки CSP
 ************************
 
-The SCF is not the only way to detect cyclostationarity in a signal, especially if you don't care about seeing cyclic frequency over RF frequency.  One simple method (both in terms of conceptually and computational complexity) involves taking the **FFT of the magnitude** of the signal, and looking for spikes.  In Python this is extremely simple:
+SCF — не єдиний спосіб виявляти циклостаціонарність сигналу, особливо якщо вам не потрібно розглядати циклічну частоту як функцію RF-частоти.  Проста (і концептуально, і обчислювально) техніка передбачає взяття **FFT від модуля** сигналу й пошук піків.  У Python це виглядає так:
 
 .. code-block:: python
 
@@ -540,9 +540,9 @@ The SCF is not the only way to detect cyclostationarity in a signal, especially 
     #samples_mag = samples * np.conj(samples) # pretty much the same as line above
     magnitude_metric = np.abs(np.fft.fft(samples_mag))
 
-Note that this method is effectively the same as multiplying the signal by the complex conjugate of itself, then taking the FFT.
+Зверніть увагу, що цей метод еквівалентний множенню сигналу на власне комплексне спряження з наступним взяттям FFT.
 
-Before plotting the metric we will null out the DC component, as it will contain a lot of energy and throw off the dynamic range.  We will also get rid of half of the FFT output, because the input to the FFT is real, so the output is symmetric.  We can then plot the metric and see the spikes:
+Перед побудовою графіка занулімо DC-компонент, бо вона містить багато енергії й псує динамічний діапазон.  Також відкиньмо половину виходу FFT, оскільки вхід реальний, а отже результат симетричний.  Після цього можна побудувати графік і побачити піки:
 
 .. code-block:: python
 
@@ -551,18 +551,18 @@ Before plotting the metric we will null out the DC component, as it will contain
     f = np.linspace(-0.5, 0.5, len(samples))
     plt.plot(f, magnitude_metric)
 
-You can then use a peak finding algorithm, such as SciPy's :code:`signal.find_peaks()`.  Below we plot :code:`magnitude_metric` for each of the three signals used in the Multiple Overlapping Signals section, first individually, then combined:
+Далі можна застосувати алгоритм пошуку піків, наприклад :code:`signal.find_peaks()` зі SciPy.  На рисунку нижче показано :code:`magnitude_metric` для кожного з трьох сигналів із попереднього розділу (спершу окремо, потім разом):
 
 .. image:: ../_images/non_csp_metric.svg
-   :align: center 
+   :align: center
    :target: ../_images/non_csp_metric.svg
-   :alt: Metric for detecting cyclostationarity in a signal without using a CAF or SCF
+   :alt: Метрика для виявлення циклостаціонарності без використання CAF чи SCF
 
-The rectangular BPSK harmonics are unfortunately overlapping with the other signal's cyclic frequencies, but this shows one downside of this alternative approach: you can't view cyclic frequency over RF frequency like in the SCF.  
+Гармоніки прямокутного BPSK, на жаль, перекриваються з циклічними частотами інших сигналів — це демонструє недолік цього альтернативного підходу: він не дозволяє розглядати циклічну частоту як функцію RF-частоти, як це робить SCF.
 
-While this method exploits cyclostationarity in signals, it's typically not considered a "CSP technique", perhaps due to its simplicity...
+Хоч цей метод і використовує циклостаціонарність сигналів, його зазвичай не відносять до «технік CSP», можливо, через простоту...
 
-For finding the RF frequency of a signal, i.e., the carrier frequency offset, there is a similar trick.  For BPSK signals, all you have to do is take the FFT of the signal squared (this will be a complex input to the FFT).  It will show a spike at the carrier frequency offset multiplied by two.  For QPSK signals, you can take the FFT of the signal to the 4th power, and it will show a spike at the carrier frequency offset multiplied by 4.
+Для пошуку RF-частоти сигналу, тобто зсуву несучої, існує схожий прийом.  Для сигналів BPSK достатньо взяти FFT від сигналу у квадраті (вхід FFT буде комплексним).  Це дасть пік на частоті, що дорівнює подвоєному зсуву несучої.  Для QPSK можна взяти FFT від сигналу в четвертій степені й отримати пік на частоті, що дорівнює зсуву несучої, помноженому на 4.
 
 .. code-block:: python
 
@@ -574,35 +574,35 @@ For finding the RF frequency of a signal, i.e., the carrier frequency offset, th
     quartic_metric = np.abs(np.fft.fftshift(np.fft.fft(samples_quartic)))/len(samples)
     quartic_metric[len(quartic_metric)//2] = 0 # null out the DC component
 
-You can try this method out on your own simulated or captured signals, it's very useful outside of CSP.
+Спробуйте цей метод на своїх симульованих чи записаних сигналах — він дуже корисний і поза CSP.
 
 *********************************
-Spectral Coherence Function (COH)
+Функція спектральної когерентності (COH)
 *********************************
 
-*TLDR: The spectral coherence function is a normalized version of the SCF that, in some situations, is worth using in place of the regular SCF.*
+*Коротко: функція спектральної когерентності — це нормалізована версія SCF, яка в деяких випадках є кориснішою за звичайну SCF.*
 
-Another measure of cyclostationarity, which can prove more insightful than the raw SCF in many cases, is the Spectral Coherence Function (COH). The COH takes the SCF and normalizes it such that the result lies between -1 and 1 (although we will be looking at magnitude which is between 0 and 1). This is useful because it isolates the information about the cyclostationarity of the signal from information about the signal's power spectrum, both of which are contained in the raw SCF. By normalizing, the power spectrum information is removed from the result leaving only the effects of cyclic correlation.
+Ще одна міра циклостаціонарності, що в багатьох випадках може дати більше інформації, ніж «сире» SCF, — це функція спектральної когерентності (COH).  COH нормалізує SCF так, що результат лежить у діапазоні від -1 до 1 (ми розглядатимемо модуль, тобто 0–1).  Це корисно, адже із результату вилучається інформація про спектр потужності сигналу, яку містить «сире» SCF. Нормалізація залишає лише впливи циклічної кореляції.
 
-To aide in one's understanding of the COH, it is helpful to review the concept of the `correlation coefficient <https://en.wikipedia.org/wiki/Pearson_correlation_coefficient>`_ from statistics. The correlation coefficient :math:`\rho_{X,Y}` quantifies the degree to which two random variables :math:`X` and :math:`Y` are related, on a scale from -1 to 1. It is defined as the covariance divided by the product of the standard deviations:
+Щоб краще зрозуміти COH, згадаємо `коефіцієнт кореляції <https://en.wikipedia.org/wiki/Pearson_correlation_coefficient>`_ зі статистики.  Коефіцієнт кореляції :math:`\rho_{X,Y}` вимірює зв’язок між двома випадковими величинами :math:`X` і :math:`Y` у діапазоні -1…1.  Він визначається як ковариація, поділена на добуток стандартних відхилень:
 
 .. math::
     \rho_{X,Y} = \frac{E[(X-\mu_X)(Y-\mu_Y)]}{\sigma_X \sigma_Y}
 
-The COH extends this concept to spectral correlation such that it quantifies the degree to which the power spectral density (PSD) of a signal at one frequency is related to the PSD of the same signal at another frequency.  These two frequencies are simply the frequency shifts that we apply as part of calculating the SCF.  To calculate the COH, we first calculate the SCF as before, denoted :math:`S_X(f,\alpha)`, and then normalize by the product of two shifted PSD terms, analogous to normalizing by the product of standard deviations:
+COH розширює цю концепцію на спектральну кореляцію: він оцінює, наскільки PSD сигналу на одній частоті пов’язана з PSD того самого сигналу на іншій частоті.  Ці дві частоти — це частотні зсуви, які ми застосовуємо під час обчислення SCF.  Щоб обчислити COH, спершу обчислюємо SCF (позначимо його :math:`S_X(f,\alpha)`), а потім нормалізуємо, поділивши на добуток двох зсунених PSD, аналогічно до поділу на добуток стандартних відхилень:
 
 .. math::
     \rho = C_x(f, \alpha) = \frac{S_X(f,\alpha)}{\sqrt{C_x^0(f + \alpha/2) C_x^0(f - \alpha/2)}}
 
-The denominator is the important/new part, the two terms :math:`C_x^0(f + \alpha/2)` and :math:`C_x^0(f - \alpha/2)` are simply the PSD shifted by :math:`\alpha/2` and :math:`-\alpha/2`. Another way to think about this is that the SCF is a cross-spectral density (a power spectrum that involves two input signals) while the normalizing terms in the denominator are the auto-spectral densities (power spectra that involve only one input signal).
+Знаменник — ключовий новий елемент: :math:`C_x^0(f + \alpha/2)` та :math:`C_x^0(f - \alpha/2)` — це PSD, зсунуті на :math:`\alpha/2` та :math:`-\alpha/2`.  Іншими словами, SCF — це крос-спектральна густина (спектр потужності з двома вхідними сигналами), а нормувальні члени в знаменнику — автоспектральні густини (спектри потужності для одного сигналу).
 
-We will now apply this to our Python code, specifically the SCF using the frequency smoothing method (FSM).  Because the FSM does the averaging in the frequency domain, we already have :math:`C_x^0(f + \alpha/2)` and :math:`C_x^0(f - \alpha/2)` at our disposal, in the Python code they are simply :code:`np.roll(X, -shift)` and :code:`np.roll(X, shift)` because :code:`X` is our signal after taking the FFT.  So all we have to do is multiply them together, take the square root, and divide our SCF slice by that result (note that this happens within the for loop over alpha):
+Застосуймо це до нашого коду, зокрема до SCF, обчисленого методом FSM.  Оскільки FSM виконує усереднення в частотній області, ми вже маємо :math:`C_x^0(f + \alpha/2)` та :math:`C_x^0(f - \alpha/2)`, які в коді відповідають :code:`np.roll(X, -shift)` та :code:`np.roll(X, shift)`, адже :code:`X` — це FFT сигналу.  Тож залишилось перемножити їх, взяти корінь і поділити зріз SCF на цей результат (зверніть увагу, що це відбувається всередині циклу за :math:`\alpha`):
 
 .. code-block:: python
 
     COH_slice = SCF_slice / np.sqrt(np.roll(X, -shift) * np.roll(X, shift))
 
-Lastly, we will repeat the same convolve and decimation that we did to calculate the final SCF slice 
+Нарешті повторимо згортку та проріджування, як і для SCF:
 
 .. code-block:: python
 
@@ -611,7 +611,7 @@ Lastly, we will repeat the same convolve and decimation that we did to calculate
 .. raw:: html
 
    <details>
-   <summary>Expand for the full code to generate and plot both the SCF and COH</summary>
+   <summary>Показати повний код для побудови SCF та COH</summary>
 
 .. code-block:: python
 
@@ -619,9 +619,9 @@ Lastly, we will repeat the same convolve and decimation that we did to calculate
     Nw = 256 # window length
     N = len(samples) # signal length
     window = np.hanning(Nw)
-    
+
     X = np.fft.fftshift(np.fft.fft(samples)) # FFT of entire signal
-    
+
     num_freqs = int(np.ceil(N/Nw)) # freq resolution after decimation
     SCF = np.zeros((len(alphas), num_freqs), dtype=complex)
     COH = np.zeros((len(alphas), num_freqs), dtype=complex)
@@ -653,65 +653,66 @@ Lastly, we will repeat the same convolve and decimation that we did to calculate
 
    </details>
 
-Now let us calculate the COH (as well as regular SCF) for a rectangular BPSK signal with 20 samples per symbol and 0.2 Hz frequency offset:
+Обчислимо COH (та звичайну SCF) для прямокутного BPSK із 20 відліками на символ і частотним зсувом 0.2 Гц:
 
 .. image:: ../_images/scf_coherence.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_coherence.svg
-   :alt: SCF and COH of a rectangular BPSK signal with 20 samples per symbol and 0.2 Hz frequency offset
+   :alt: SCF і COH прямокутного сигналу BPSK із 20 відліками на символ і зсувом 0.2 Гц
 
-As you can see, the higher alphas are much more pronounced in the COH than in the SCF.  Running the same code on the pulse-shaped BPSK signal we find there is not a ton of difference:
+Бачимо, що в COH значно виразніші високі значення :math:`\alpha`, ніж у SCF.  Якщо запустити той самий код для BPSK із формуванням імпульсу, різниця буде не такою помітною:
 
 .. image:: ../_images/scf_coherence_pulse_shaped.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_coherence_pulse_shaped.svg
-   :alt: SCF and COH of a pulse-shaped BPSK signal with 20 samples per symbol and 0.2 Hz frequency offset
+   :alt: SCF і COH сигналу BPSK з формуванням імпульсу, 20 відліків на символ, зсув 0.2 Гц
 
-Try generating both the SCF and COH for your application to see which one works best!
+Спробуйте обчислити SCF і COH для вашої задачі, щоб визначити, який варіант підходить краще!
 
 **********
-Conjugates
+Спряжені варіанти
 **********
 
-Up until this point, we have been using the following formulas for the CAF and the SCF where the complex conjugate (:math:`*` symbol) of the signal is used in the second term:
+Досі ми використовували такі формули для CAF і SCF, де в другому множнику застосовується комплексне спряження (:math:`*`):
 
 .. math::
     R_x(\tau,\alpha) = \lim_{T\rightarrow\infty} \frac{1}{T} \int_{-T/2}^{T/2} x(t + \tau/2)x^*(t - \tau/2)e^{-j2\pi \alpha t}dt \\
     S_X(f,\alpha) = \lim_{T\rightarrow\infty} \frac{1}{T} \lim_{U\rightarrow\infty} \frac{1}{U} \int_{-U/2}^{U/2} X(t,f + \alpha/2) X^*(t,f - \alpha/2) dt
 
-There is, however, an alternate form for the CAF and SCF in which there is no conjugate included. These forms are called the *conjugate CAF* and the *conjugate SCF*, respectively.  The naming convention it's a little confusing, but the main thing to remember is that there's a "normal" version of the CAF/SCF, and a conjugate version.  The conjugate version is useful when you want to extract more information from the signal, but it's not always necessary depending on the signal.  The conjugate CAF and SCF are defined as:
+Однак існує альтернативна форма CAF і SCF без спряження.  Їх називають *спряженою CAF* та *спряженою SCF*.  Назва трохи заплутана, але головне пам’ятати, що існує «звичайна» версія CAF/SCF і спряжена версія.  Спряжені варіанти дозволяють отримати більше інформації із сигналу, але не завжди потрібні залежно від ситуації.  Визначення спряжених функцій:
 
 .. math::
     R_{x^*}(\tau,\alpha) = \lim_{T\rightarrow\infty} \frac{1}{T} \int_{-T/2}^{T/2} x(t + \tau/2)x(t - \tau/2)e^{-j2\pi \alpha t}dt \\
     S_{x^*}(f,\alpha) = \lim_{T\rightarrow\infty} \frac{1}{T} \lim_{U\rightarrow\infty} \frac{1}{U} \int_{-U/2}^{U/2} X(t,f + \alpha/2) X(t,f - \alpha/2) dt
 
-which is the same as the original CAF and SCF, but without the conjugate.  The discrete time versions are also all the same except for the conjugate being removed.
+Це ті самі вирази, що й для оригінальних CAF і SCF, але без спряження.  Дискретні версії відрізняються лише відсутністю спряження.
 
-To understand the significance of the conjugate forms, consider the quadrature representation of a real-valued bandpass signal:
+Щоб зрозуміти сенс спряжених форм, розгляньмо квадратурне представлення реального смугового сигналу:
 
 .. math::
     y(t) = x_I(t) \cos(2\pi f_c t + \phi) + x_Q(t) \sin(2\pi f_c t + \phi)
 
-:math:`x_I(t)` and :math:`x_Q(t)` are the in-phase (I) and quadrature (Q) components of the signal, respectively, and it is these IQ samples that we are ultimately processing with CSP at baseband.
+де :math:`x_I(t)` та :math:`x_Q(t)` — відповідно інфазна та квадратурна компоненти сигналу, тобто IQ-відліки, які ми обробляємо на базовій частоті.
 
-Using Euler's formula, :math:`e^{jx} = \cos(x) + j \sin(x)`, we can rewrite the above equation using complex exponentials:
+Використовуючи формулу Ейлера :math:`e^{jx} = \cos(x) + j \sin(x)`, перепишемо вище наведений вираз через комплексні експоненти:
 
 .. math::
     y(t) = \frac{x_I(t) - j x_Q(t)}{2} e^{j 2\pi f_c t + j \phi} + \frac{x_I(t) + j x_Q(t)}{2} e^{-j 2\pi f_c t - j \phi}
 
-We can use complex envelope, which we will call :math:`z(t)`, to represent the real-valued signal :math:`y(t)`, assuming that the signal bandwidth is much smaller than the carrier frequency :math:`f_c` which is typically the case in RF applications:
+Можемо представити реальний сигнал :math:`y(t)` через комплексну огинаючу :math:`z(t)`, припускаючи, що смуга сигналу значно вужча за несучу :math:`f_c`, що типовою для RF-застосувань:
 
 .. math::
     y(t) = z(t) e^{j 2 \pi f_c t + j \phi} + z^*(t) e^{-j 2 \pi f_c t - j \phi}
 
-This is known as the complex-baseband representation.
+Це називається комплексно-базовим представленням.
 
-Coming back to the CAF, let's try computing the portion of the CAF known as the "lag product", which is just the :math:`x(t + \tau/2) x(t - \tau/2)` part:
+Повернімося до CAF і спробуймо обчислити «лаговий добуток», тобто частину :math:`x(t + \tau/2) x(t - \tau/2)`:
 
 .. math::
-    \left(z(t + \tau/2) e^{j 2 \pi f_c (t + \tau/2) + j \phi} + z^*(t + \tau/2) e^{-j 2 \pi f_c (t + \tau/2) - j \phi}\right) \times \\ \left(z(t - \tau/2) e^{j 2 \pi f_c (t - \tau/2) + j \phi} + z^*(t - \tau/2) e^{-j 2 \pi f_c (t - \tau/2) - j \phi}\right)
+    \left(z(t + \tau/2) e^{j 2 \pi f_c (t + \tau/2) + j \phi} + z^*(t + \tau/2) e^{-j 2 \pi f_c (t + \tau/2) - j \phi}\right) \times \\
+    \left(z(t - \tau/2) e^{j 2 \pi f_c (t - \tau/2) + j \phi} + z^*(t - \tau/2) e^{-j 2 \pi f_c (t - \tau/2) - j \phi}\right)
 
-Although it may not be immediately obvious, this result contains four terms corresponding to the four combinations of conjugated and non-conjugated :math:`z(t)`:
+Хоч це неочевидно одразу, результат містить чотири доданки — усі комбінації спряжених і неспряжених :math:`z(t)`:
 
 .. math::
     z(t + \tau/2) z(t - \tau/2) e^{(\ldots)} \\
@@ -719,20 +720,20 @@ Although it may not be immediately obvious, this result contains four terms corr
     z^*(t + \tau/2) z(t - \tau/2) e^{(\ldots)} \\
     z^*(t + \tau/2) z^*(t - \tau/2) e^{(\ldots)}
 
-It turns out that the 1st and 4th ones are effectively the same thing as far as information we can obtain from them, as are the 2nd and 3rd.  So there are really only two cases we care about, the conjugate case and the non-conjugate case.  In summary, if one wishes to obtain the full extent of statistical information from :math:`y(t)`, each combination of conjugated and non-conjugated terms must be considered.
+Виявляється, що перший та четвертий доданки по суті несуть однакову інформацію, як і другий із третім.  Тож залишаються дві справді важливі комбінації — зі спряженням і без нього.  Підсумовуючи: щоб отримати всю статистичну інформацію зі :math:`y(t)`, потрібно розглянути всі комбінації спряжених та неспряжених членів.
 
-In order to implement the conjugate SCF using the frequency smoothing method, there is one extra step beyond removing the :code:`conj()`, because we are doing one big FFT and then averaging in the frequency domain.  There is a property of the Fourier transform that states that a complex conjugate in the time domain corresponds to the frequency domain being flipped and conjugated:
+Щоб реалізувати спряжену SCF методом FSM, потрібно зробити ще один крок понад просте видалення :code:`conj()`, адже ми беремо один великий FFT і усереднюємо в частотній області.  Існує властивість перетворення Фур’є: комплексне спряження у часовій області відповідає перевернутому й спряженому спектру:
 
 .. math::
     x^*(t) \leftrightarrow X^*(-f)
 
-Now because we were already complex conjugating the second term in the normal SCF (recall that we were using the code :code:`SCF_slice = np.roll(X, -shift) * np.conj(np.roll(X, shift))`), when we complex conjugate it again it just goes away, so what we are left with is the following:
+Оскільки в звичайній SCF ми вже брали комплексне спряження другого множника (пригадайте код :code:`SCF_slice = np.roll(X, -shift) * np.conj(np.roll(X, shift))`), при додатковому спряженні воно просто зникає, і залишається таке:
 
 .. code-block:: python
 
     SCF_slice = np.roll(X, -shift) * np.flip(np.roll(X, -shift - 1))
 
-Note the added :code:`np.flip()`, and the :code:`roll()` needs to happen in the reverse direction.  The full FSM implementation of the conjugate SCF is as follows:
+Зверніть увагу на доданий :code:`np.flip()` та те, що зсув :code:`roll()` відбувається в протилежному напрямку.  Повна реалізація FSM для спряженої SCF виглядає так:
 
 .. code-block:: python
 
@@ -742,7 +743,7 @@ Note the added :code:`np.flip()`, and the :code:`roll()` needs to happen in the 
     window = np.hanning(Nw)
 
     X = np.fft.fftshift(np.fft.fft(samples)) # FFT of entire signal
-    
+
     num_freqs = int(np.ceil(N/Nw)) # freq resolution after decimation
     SCF = np.zeros((len(alphas), num_freqs), dtype=complex)
     for i in range(len(alphas)):
@@ -757,67 +758,67 @@ Note the added :code:`np.flip()`, and the :code:`roll()` needs to happen in the 
     plt.ylabel('Cyclic Frequency [Normalized Hz]')
     plt.show()
 
-Another big change with the conjugate SCF is that we want to calculate alphas between -1 and +1, whereas with the normal SCF we just did 0.0 to 0.5 due to symmetry.  You will see why this is the case first-hand once we start looking at the conjugate SCF of example signals.
+Ще одна важлива відмінність спряженої SCF — необхідність обчислювати :math:`\alpha` у діапазоні від -1 до +1, тоді як у звичайній SCF ми використовували 0.0–0.5 через симетрію.  Ви зрозумієте чому, коли побачите приклади спряженої SCF.
 
-Now what is the importance of doing the conjugate SCF?  To demonstrate, let's look at the conjugate SCF of our basic rectangular BPSK signal with 20 samples per symbol (leading to a cyclic frequency of 0.05 Hz) and 0.2 Hz frequency offset:
+Що ж нам дає спряжена SCF?  Для початку подивімося на спряжену SCF нашого базового прямокутного BPSK із 20 відліками на символ (циклічна частота 0.05 Гц) і частотним зсувом 0.2 Гц:
 
 .. image:: ../_images/scf_conj_rect_bpsk.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_conj_rect_bpsk.svg
-   :alt: Conjugate SCF of rectangular BPSK using the Frequency Smoothing Method (FSM)
+   :alt: Спряжена SCF прямокутного BPSK, обчислена методом FSM
 
-Here is the big take-away from this section: what you ultimately get in the conjugate SCF are spikes at the cyclic frequency +/- **twice** the carrier frequency offset, which we will refer to as :math:`f_c`. In the frequency axis it will be centered at 0 Hz instead of :math:`f_c`.  Our frequency offset was 0.2 Hz, so we end up getting spikes at 0.4 Hz +/- the cyclic frequency of 0.05 Hz.  If there is one thing to remember about the conjugate SCF, it is to expect spikes at:
+Головний висновок: у спряженій SCF з’являються піки на циклічній частоті +/- **подвійний** зсув несучої, позначимо його :math:`f_c`.  На осі частоти вони зосереджені навколо 0 Гц, а не :math:`f_c`.  У нашому прикладі :math:`f_c = 0.2` Гц, тож спостерігаємо піки на 0.4 +/- 0.05 Гц.  Якщо запам’ятати щось одне про спряжену SCF, то це таке співвідношення:
 
 .. math::
     2f_c \pm \alpha
 
-Let's now look at pulse-shaped BPSK with the same 0.2 Hz offset, 20 samples per symbol, and a 0.3 roll-off:
+Розгляньмо BPSK із формуванням імпульсу з тими ж параметрами (зсув 0.2 Гц, 20 відліків на символ, roll-off 0.3):
 
 .. image:: ../_images/scf_conj_pulseshaped_bpsk.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_conj_pulseshaped_bpsk.svg
-   :alt: Conjugate SCF of raised cosine pulse-shaped BPSK using the Frequency Smoothing Method (FSM)
+   :alt: Спряжена SCF BPSK із формуванням імпульсу RC, обчислена методом FSM
 
-Seems reasonable given the normal SCF pattern we saw with BPSK.
+Результат цілком відповідає очікуваному з урахуванням звичайної SCF для BPSK.
 
-Now for the fun part, let's look at the conjugate SCF of rectangular QPSK with the same 0.2 Hz and 20 samples per symbol:
+А тепер найцікавіше — розглянемо спряжену SCF прямокутного QPSK з тими ж 0.2 Гц і 20 відліками на символ:
 
 .. image:: ../_images/scf_conj_rect_qpsk.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_conj_rect_qpsk.svg
-   :alt: Conjugate SCF of rectangular QPSK using the Frequency Smoothing Method (FSM)
+   :alt: Спряжена SCF прямокутного QPSK, обчислена методом FSM
 
-At first it might seem like there was a bug in our code, but take a look at the colorbar, which indicates what values the colors correspond to.  When using :code:`plt.imshow()` with automatic scaling, you have to be aware that it's always going to scale the colors (in our case, purple through yellow) from the lowest value to the highest value of the 2D array we give it.  In the case of our conjugate SCF of QPSK, the entire output is relatively low, because it turns out *there are no spikes in the conjugate SCF when using QPSK*.  Here is the same QPSK output but using the scaling to match our previous BPSK examples:
+Спершу може здатися, що в коді помилка, але погляньте на кольорову шкалу — вона показує, які значення відповідають кольорам.  Якщо використовувати :code:`plt.imshow()` зі стандартним масштабуванням, треба пам’ятати, що кольори (у нас — від фіолетового до жовтого) завжди масштабуються від мінімального до максимального значення вхідного 2D-масиву.  У випадку спряженої SCF QPSK весь результат дуже малий, адже *піки відсутні*.  Ось той самий результат, але зі шкалою, як у попередніх прикладах BPSK:
 
 .. image:: ../_images/scf_conj_rect_qpsk_scaled.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_conj_rect_qpsk_scaled.svg
-   :alt: Conjugate SCF of rectangular QPSK using the Frequency Smoothing Method (FSM) with scaling
+   :alt: Спряжена SCF прямокутного QPSK (FSM) із переналаштованою шкалою
 
-Note the range of the colorbar.
+Зверніть увагу на діапазон кольорової шкали.
 
-The conjugate SCF for QPSK, as well as higher order PSK and QAM, is essentially zero/noise.  This means we can use the conjugate SCF to detect the presence of BPSK (e.g., the chipping sequence in DSSS) even if there are a bunch of QPSK/QAM signals overlapping with it.  This is a very powerful tool in the CSP toolbox!
+Спряжена SCF для QPSK, а також для PSK та QAM вищих порядків, фактично дорівнює нулю/шуму.  Це означає, що спряжену SCF можна використати для виявлення сигналів BPSK (наприклад, чипової послідовності в DSSS), навіть якщо одночасно присутні численні сигнали QPSK/QAM.  Дуже потужний інструмент у наборі CSP!
 
-Let's try running the conjugate SCF on the three-signal scenario we've been using several times throughout this tutorial, which includes the following signals:
+Розгляньмо спряжену SCF для сценарію з трьома сигналами, який ми використовували раніше:
 
-* Signal 1: Rectangular BPSK with 20 samples per symbol and 0.2 Hz frequency offset
-* Signal 2: Pulse-shaped BPSK with 20 samples per symbol, -0.1 Hz frequency offset, and 0.35 roll-off
-* Signal 3: Pulse-shaped QPSK with 4 samples per symbol, 0.2 Hz frequency offset, and 0.21 roll-off
+* Сигнал 1: прямокутний BPSK із 20 відліками на символ і частотним зсувом 0.2 Гц
+* Сигнал 2: BPSK із формуванням імпульсу, 20 відліків на символ, частотний зсув -0.1 Гц, коефіцієнт roll-off 0.35
+* Сигнал 3: QPSK із формуванням імпульсу, 4 відліки на символ, частотний зсув 0.2 Гц, коефіцієнт roll-off 0.21
 
 .. image:: ../_images/scf_conj_multiple_signals.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_conj_multiple_signals.svg
-   :alt: Conjugate SCF of three different signals using the Frequency Smoothing Method (FSM)
+   :alt: Спряжена SCF трьох сигналів, обчислена методом FSM
 
-Notice how we can see the two BPSK signals but the QPSK signal doesn't show up, or else we would see a spike at alpha = 0.65 and 0.15 Hz.  It might be hard to see without zooming in, but there are spikes at 0.4 +/- 0.05 Hz and -0.2 +/- 0.05 Hz.
+Бачимо обидва сигнали BPSK, а сигнал QPSK не проявляється — інакше ми б побачили пік на :math:`\alpha = 0.65` та 0.15 Гц.  Якщо придивитися, видно піки на 0.4 +/- 0.05 Гц і -0.2 +/- 0.05 Гц.
 
 ********************************
-FFT Accumulation Method (FAM)
+Метод накопичення FFT (FAM)
 ********************************
 
-The FSM and TSM techniques presented earlier work great, especially when you want to calculate a specific set of cyclic frequencies (note how both implementations involve looping over cyclic frequency as the outer loop). However, there is an even more efficient SCF implementation known as the FFT Accumulation Method (FAM), which inherently calculates the full set of cyclic frequencies (i.e., the cyclic frequencies corresponding to every integer shift of the signal, the number of which depend on signal length).  There is also a similar technique known as the `Strip Spectral Correlation Analyzer (SSCA) <https://cyclostationary.blog/2016/03/22/csp-estimators-the-strip-spectral-correlation-analyzer/>`_ which also calculates all cyclic frequencies at once, but is not covered in this chapter to avoid repetition.  This class of techniques that calculate all cyclic frequencies are sometimes referred to as "blind estimators" because they tend to be used when no prior knowledge of cyclic frequencies is known (otherwise, you would have a good idea of which cyclic frequencies to calculate and could use the FSM or TSM methods).  The FAM is a time-smoothing method (think of it like a fancy TSM), while the SSCA is like a fancy FSM.
+Методи FSM і TSM чудово працюють, особливо коли потрібно обчислити конкретний набір циклічних частот (зверніть увагу, що в обох реалізаціях зовнішнім циклом є перебір :math:`\alpha`). Проте існує ще ефективніша реалізація SCF — метод накопичення FFT (FFT Accumulation Method, FAM), який автоматично обчислює *всі* циклічні частоти (тобто ті, що відповідають кожному цілочисельному зсуву сигналу; їх кількість залежить від довжини сигналу).  Існує схожий підхід, відомий як `Strip Spectral Correlation Analyzer (SSCA) <https://cyclostationary.blog/2016/03/22/csp-estimators-the-strip-spectral-correlation-analyzer/>`_, який також обчислює всі циклічні частоти за раз, але щоб уникнути повторів, ми не розглядатимемо його тут.  Цей клас методів іноді називають «сліпими оцінювачами», адже їх використовують, коли наперед невідомо, які циклічні частоти очікуються (інакше можна було б оцінити потрібні :math:`\alpha` за допомогою FSM чи TSM).  FAM належить до методів згладжування за часом (сприймайте його як удосконалений TSM), тоді як SSCA — як удосконалений FSM.
 
-The minimal Python code to implement the FAM is actually fairly simple, although because we are no longer looping over alpha it is not as easy to tie back to the math.  Just like the TSM, we break the signal into a bunch of time windows, with some overlap.  A Hanning window is applied to each chunk of samples.  There are two stages of FFTs performed as part of the FAM algorithm, and within the code note that the first FFT is performed on a 2D array, so it's doing a bunch of FFTs in one line of code.  After a frequency shift, we do a second FFT to build the SCF (we then take the magnitude squared).  For a more thorough explanation of the FAM, refer to the external resources at the end of this section.
+Мінімальна реалізація FAM на Python досить проста, хоча через відсутність явного циклу за :math:`\alpha` складніше співвіднести її з математикою.  Як і в TSM, ми ділимо сигнал на часові вікна з певним перекриттям та застосовуємо вікно Ганна.  Алгоритм FAM виконує два етапи FFT; зверніть увагу, що перше FFT застосовується до 2D-масиву, тож за один рядок виконується багато окремих FFT.  Після частотного зсуву виконується друге FFT для побудови SCF (потім беремо квадрат модуля).  Детальніше про FAM можна прочитати в матеріалах наприкінці розділу.
 
 .. code-block:: python
 
@@ -861,27 +862,27 @@ The minimal Python code to implement the FAM is actually fairly simple, although
             SCF[a-Mp:a+Mp, i] = np.abs(XF2[(P//2-Mp):(P//2+Mp)])**2
 
 .. image:: ../_images/scf_fam.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_fam.svg
-   :alt: SCF with the FFT Accumulation Method (FAM), showing cyclostationary signal processing
+   :alt: SCF, обчислена методом накопичення FFT (FAM)
 
-Let's zoom into the interesting part around 0.2 Hz and the low cyclic frequencies, to see more detail:
+Збільшимо ділянку навколо 0.2 Гц і низьких циклічних частот, щоб побачити деталі:
 
 .. image:: ../_images/scf_fam_zoomedin.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_fam_zoomedin.svg
-   :alt: Zoomed in version of SCF with the FFT Accumulation Method (FAM), showing cyclostationary signal processing
+   :alt: Збільшений фрагмент SCF, обчисленої методом FAM
 
-There is a clear hot spot at 0.05 Hz, and a low one at 0.1 Hz that may be tough to see with this colorscale.
+Помітний яскравий максимум на 0.05 Гц і менш виразний на 0.1 Гц (його може бути важко розгледіти з такою шкалою).
 
-We can also squash the RF frequency axis and plot the SCF in 1D, in order to more easily see which cyclic frequencies are present:
+Можна також «сплющити» вісь RF-частоти та побудувати SCF в 1D, щоб легше побачити присутні циклічні частоти:
 
 .. image:: ../_images/scf_fam_1d.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_fam_1d.svg
-   :alt: Cyclic freq plot using the FFT Accumulation Method (FAM), showing cyclostationary signal processing
+   :alt: Циклічні частоти, отримані методом FAM
 
-One big gotcha with the FAM is that it will generate an enormous number of pixels, depending on your signal size, and when only one or two rows in the :code:`imshow()` contain the energy, they can sometimes be masked due to the scaling done to display it on your monitor.  Make sure to note the size of the 2D SCF matrix, and if you want to reduce the number of pixels in the cyclic frequency axis, you can use a max pooling or mean pooling operation.  Place this code after the SCF calculation and before plotting (you may need to :code:`pip install scikit-image`):
+Одне з підводних каменів FAM — дуже велика кількість пікселів (залежно від довжини сигналу). Якщо енергія зосереджена лише в кількох рядках :code:`imshow()`, їх може бути важко побачити через масштабування при відображенні на екрані.  Зверніть увагу на розмір 2D-матриці SCF; якщо хочете зменшити кількість пікселів за циклічною частотою, можна застосувати max pooling або average pooling.  Розмістіть наступний код після обчислення SCF і до відображення (можливо, доведеться виконати :code:`pip install scikit-image`):
 
 .. code-block:: python
 
@@ -891,19 +892,19 @@ One big gotcha with the FAM is that it will generate an enormous number of pixel
     SCF = skimage.measure.block_reduce(SCF, block_size=(16, 1), func=np.max) # type: ignore
     print("New shape of SCF:", SCF.shape)
 
-External Resources on FAM:
+Додаткові джерела про FAM:
 
-* R.S. Roberts, W. A. Brown, and H. H. Loomis, Jr., "Computationally Efficient Algorithms for Cyclic Spectral Analysis," IEEE Signal Processing Magazine, April 1991, pp. 38-49. `Available here <https://www.researchgate.net/profile/Faxin-Zhang-2/publication/353071530_Computationally_efficient_algorithms_for_cyclic_spectral_analysis/links/60e69d2d30e8e50c01eb9484/Computationally-efficient-algorithms-for-cyclic-spectral-analysis.pdf>`_
-* Da Costa, Evandro Luiz. Detection and identification of cyclostationary signals. Diss. Naval Postgraduate School, 1996. `Available here <https://apps.dtic.mil/sti/pdfs/ADA311555.pdf>`_
-* Chad's blog post on FAM: https://cyclostationary.blog/2018/06/01/csp-estimators-the-fft-accumulation-method/
+* R.S. Roberts, W. A. Brown, and H. H. Loomis, Jr., "Computationally Efficient Algorithms for Cyclic Spectral Analysis," IEEE Signal Processing Magazine, April 1991, pp. 38-49. `Доступно тут <https://www.researchgate.net/profile/Faxin-Zhang-2/publication/353071530_Computationally_efficient_algorithms_for_cyclic_spectral_analysis/links/60e69d2d30e8e50c01eb9484/Computationally-efficient-algorithms-for-cyclic-spectral-analysis.pdf>`_
+* Da Costa, Evandro Luiz. Detection and identification of cyclostationary signals. Diss. Naval Postgraduate School, 1996. `Доступно тут <https://apps.dtic.mil/sti/pdfs/ADA311555.pdf>`_
+* Публікація Chada про FAM: https://cyclostationary.blog/2018/06/01/csp-estimators-the-fft-accumulation-method/
 
 ********************************
 OFDM
 ********************************
 
-Cyclostationarity is especially strong in OFDM signals due to OFDM's use of a cyclic prefix (CP), which is where the last several samples of each OFDM symbol is copied and added to the beginning of the OFDM symbol.  This leads to a strong cyclic frequency corresponding to the OFDM symbol length (which is equal to the inverse of the subcarrier spacing, plus CP duration). 
+Циклостаціонарність особливо виражена в OFDM-сигналах через використання циклічного префікса (CP), коли кілька останніх відліків кожного OFDM-символу копіюються на його початок.  Це створює сильну циклічну частоту, що відповідає довжині OFDM-символу (яка дорівнює оберненій величині міжсубдіапазонного інтервалу плюс тривалість CP).
 
-Let's play around with an OFDM signal.  Below is the simulation of an OFDM signal with a CP using 64 subcarriers, 25% CP, and QPSK modulation on each subcarrier.  We'll interpolate by 2x to simulate receiving at a reasonable sample rate, so that means the OFDM symbol length in number of samples will be (64 + (64*0.25)) * 2 = 160 samples.  That means we should get spikes at alphas that are an integer multiple of 1/160, or 0.00625, 0.0125, 0.01875, etc. We will simulate 100k samples which corresponds to 625 OFDM symbols (recall that each OFDM symbol is fairly long).  
+Змоделюймо OFDM-сигнал.  Нижче наведено код, який генерує OFDM із CP, використовуючи 64 піднесучі, 25% CP і QPSK на кожній піднесучій.  Ми інтерполюємо сигнал удвічі, щоб змоделювати приймання з достатньо високою швидкістю дискретизації, тому довжина OFDM-символу в відліках становитиме (64 + (64*0.25)) * 2 = 160.  Це означає, що очікуємо піки на :math:`\alpha`, кратних 1/160 (0.00625, 0.0125, 0.01875 тощо).  Симулюємо 100 тис. відліків, що відповідає 625 OFDM-символам (кожен символ доволі довгий).
 
 .. code-block:: python
 
@@ -941,26 +942,26 @@ Let's play around with an OFDM signal.  Below is the simulation of an OFDM signa
     n = np.sqrt(np.var(samples) * 10**(-SNR_dB/10) / 2) * (np.random.randn(N) + 1j*np.random.randn(N))
     samples = samples + n
 
-Using the FSM to calculate the SCF at a relatively high cyclic resolution of 0.0001:
+Використаймо FSM для обчислення SCF з високою роздільністю за циклічною частотою (крок 0.0001):
 
 .. image:: ../_images/scf_freq_smoothing_ofdm.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_freq_smoothing_ofdm.svg
-   :alt: SCF of OFDM using the Frequency Smoothing Method (FSM)
+   :alt: SCF OFDM-сигналу, обчислена методом FSM
 
-Note the horizontal line towards the top, indicating there is a low cyclic frequency.  Zooming into the lower cyclic frequencies, we can clearly see the cyclic frequency corresponding to the OFDM symbol length (alpha = 0.0125).  Not sure why we only get a spike at 2x, and not 1x or 3x or 4x...  Even dropping the resolution by another 10x doesn't show anything else besides the 2x, if anyone knows feel free to use the "Suggest an Edit" link at the bottom of this page.
+Зверніть увагу на горизонтальну смугу у верхній частині — вона вказує на низьку циклічну частоту.  Якщо наблизити нижній діапазон :math:`\alpha`, добре видно циклічну частоту, що відповідає довжині OFDM-символу (:math:`\alpha = 0.0125`).  Не зовсім зрозуміло, чому ми бачимо пік лише на подвоєній частоті, а не на одинарній/потрійній/четвертній...  Навіть зменшення роздільності в 10 разів не показує інших піків; якщо знаєте відповідь — натисніть «Suggest an Edit» внизу сторінки.
 
 .. image:: ../_images/scf_freq_smoothing_ofdm_zoomed_in.svg
-   :align: center 
+   :align: center
    :target: ../_images/scf_freq_smoothing_ofdm_zoomed_in.svg
-   :alt: SCF of OFDM using the Frequency Smoothing Method (FSM) zoomed into the lower cyclic freqs
+   :alt: SCF OFDM-сигналу (FSM) у збільшеній області низьких циклічних частот
 
-External resources on OFDM within the context of CSP:
+Додаткові джерела про OFDM у контексті CSP:
 
-#. Sutton, Paul D., Keith E. Nolan, and Linda E. Doyle. "Cyclostationary signatures in practical cognitive radio applications." IEEE Journal on selected areas in Communications 26.1 (2008): 13-24. `Available here <https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=4413137&casa_token=81U1yMeRKMsAAAAA:6sQr9-VngNa2p_OW4zVyeQsRdUrZPkx3L-6ZPsH9LCo-pnTxs_AhjfAx27MFBbo4kl3YlgdkQJk&tag=1>`_
+#. Sutton, Paul D., Keith E. Nolan, and Linda E. Doyle. "Cyclostationary signatures in practical cognitive radio applications." IEEE Journal on selected areas in Communications 26.1 (2008): 13-24. `Доступно тут <https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=4413137&casa_token=81U1yMeRKMsAAAAA:6sQr9-VngNa2p_OW4zVyeQsRdUrZPkx3L-6ZPsH9LCo-pnTxs_AhjfAx27MFBbo4kl3YlgdkQJk&tag=1>`_
 
 ********************************************
-Signal Detection With Known Cyclic Frequency
+Виявлення сигналів із відомою циклічною частотою
 ********************************************
 
-In some applications you may want to use CSP to detect a signal/waveform that is already known, such as variants of 802.11, LTE, 5G, etc.  If you know the cyclic frequency of the signal, and you know your sample rate, then you really only need to calculate a single alpha and single tau.  Coming soon will be an example of this type of problem using an RF recording of WiFi.
+В окремих застосунках CSP використовують для виявлення сигналу/хвилі, який вже відомий, наприклад варіантів 802.11, LTE, 5G тощо.  Якщо відома циклічна частота сигналу та частота дискретизації, достатньо обчислити один :math:`\alpha` і один :math:`\tau`.  Найближчим часом ми додамо приклад такої задачі на основі RF-запису WiFi.


### PR DESCRIPTION
## Summary
- translate the cyclostationary processing chapter into Ukrainian, covering CAF/SCF theory, implementation notes, and interactive tooling details.
- localize advanced sections on conjugate processing, FAM, OFDM examples, and detection guidance for known cyclic frequencies.

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e3e1305cb88328912a27576f73f485